### PR TITLE
[Feat] 조직 멤버 역할 변경 구현

### DIFF
--- a/src/main/java/com/llm_ops/demo/organization/controller/OrganizationMemberController.java
+++ b/src/main/java/com/llm_ops/demo/organization/controller/OrganizationMemberController.java
@@ -2,13 +2,18 @@ package com.llm_ops.demo.organization.controller;
 
 import com.llm_ops.demo.organization.dto.OrganizationMemberRemoveResponse;
 import com.llm_ops.demo.organization.dto.OrganizationMemberResponse;
+import com.llm_ops.demo.organization.dto.OrganizationMemberRoleUpdateRequest;
+import com.llm_ops.demo.organization.dto.OrganizationMemberRoleUpdateResponse;
 import com.llm_ops.demo.organization.service.OrganizationMemberService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +32,18 @@ public class OrganizationMemberController {
     ) {
         List<OrganizationMemberResponse> response =
             organizationMemberService.getMembers(organizationId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<OrganizationMemberRoleUpdateResponse> updateMemberRole(
+            @PathVariable Long organizationId,
+            @PathVariable Long memberId,
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody OrganizationMemberRoleUpdateRequest request
+    ) {
+        OrganizationMemberRoleUpdateResponse response =
+                organizationMemberService.updateMemberRole(organizationId, memberId, userId, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/llm_ops/demo/organization/dto/OrganizationMemberRoleUpdateRequest.java
+++ b/src/main/java/com/llm_ops/demo/organization/dto/OrganizationMemberRoleUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.llm_ops.demo.organization.dto;
+
+import com.llm_ops.demo.organization.domain.OrganizationRole;
+import jakarta.validation.constraints.NotNull;
+
+public record OrganizationMemberRoleUpdateRequest (
+        @NotNull(message = "역할은 필수입니다.")
+        OrganizationRole role
+) {}

--- a/src/main/java/com/llm_ops/demo/organization/dto/OrganizationMemberRoleUpdateResponse.java
+++ b/src/main/java/com/llm_ops/demo/organization/dto/OrganizationMemberRoleUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.llm_ops.demo.organization.dto;
+
+import com.llm_ops.demo.organization.domain.OrganizationRole;
+import java.time.LocalDateTime;
+
+public record OrganizationMemberRoleUpdateResponse(
+        Long memberId,
+        OrganizationRole previousRole,
+        OrganizationRole newRole,
+        LocalDateTime updatedAt
+) {
+    public static OrganizationMemberRoleUpdateResponse from(
+            Long memberId,
+            OrganizationRole previousRole,
+            OrganizationRole newRole
+    ) {
+        return new OrganizationMemberRoleUpdateResponse(
+                memberId, previousRole, newRole, LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/com/llm_ops/demo/organization/controller/OrganizationMemberControllerTest.java
+++ b/src/test/java/com/llm_ops/demo/organization/controller/OrganizationMemberControllerTest.java
@@ -170,4 +170,6 @@ class OrganizationMemberControllerTest {
                 .andExpect(status().isBadRequest());
         }
     }
+
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #53 

## ✨ 작업 내용

- 조직 멤버 역할 변경 기능 구현 (T-0214) 
- OWNER가 조직 내 멤버의 역할을 ADMIN ↔ MEMBER로 변경할 수 있는 API 추가
- PATCH /api/v1/organizations/{organizationId}/members/{memberId} 엔드포인트 추가
- OrganizationMemberRoleUpdateRequest DTO 생성
OrganizationMemberRoleUpdateResponse DTO 생성 (정적 팩토리 메서드 from() 적용)
OrganizationMemberService에 updateMemberRole()메서드 추가
OrganizationMemberController에 PATCH 엔드포인트 추가

## 📸 스크린샷 (선택)
- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부해주세요.

## 📚 레퍼런스 (선택)
- 참고한 링크나 문서가 있다면 적어주세요.

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?
기존 validateNotOwner()에러 메시지가 "OWNER는 퇴출할 수 없습니다."로 되어 있어 역할 변경 시에도 같은 메시지 노출됨 (필요시 분리 검토)
