### PR TITLE
fix(provider-key-update-modal): prevent crash on SettingsProviderKeysPage modal (updateError/handleClose)

### DIFF
--- a/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
+++ b/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
@@ -238,8 +238,15 @@ function UpdateProviderModal({
   credential: ProviderCredentialSummaryResponse | null;
 }) {
   const [apiKey, setApiKey] = useState('');
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const { currentOrgId } = useOrganizationStore();
+
+  const handleClose = () => {
+    setUpdateError(null);
+    setApiKey('');
+    onClose();
+  };
 
   const updateMutation = useMutation({
     mutationFn: () => {


### PR DESCRIPTION
## 📌 관련 이슈
- close #\n
## ✨ 작업 내용
- SettingsProviderKeysPage 모달에서 updateError 및 handleClose 경로로 인한 크래시 수정. 비정상 상태에서도 모달이 안정적으로 동작하도록 로직을 보완하고, 업데이트 중 에러 처리 흐름을 안전하게 변경했습니다.

## 📸 스크린샷 (선택)
- 해당 변경으로 UI는 유지되며 모달 크래시가 더 이상 발생하지 않습니다.

## 📚 레퍼런스 (선택)
- 관련 문서나 참고 자료가 있다면 기재합니다.

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 제공자 키 추가 및 업데이트 모달의 오류 처리 개선
  * 새로운 키 입력 시 이전 오류 메시지 자동 삭제
  * 성공적인 작업 완료 후 입력값 및 오류 상태 초기화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->