### PR TITLE
[Fix] main과 develop 브랜치 동기화 (#140)

### DIFF
--- a/frontend2/src/pages/prompt/PromptDetailPage.test.tsx
+++ b/frontend2/src/pages/prompt/PromptDetailPage.test.tsx
@@ -85,6 +85,8 @@ beforeEach(() => {
       modelConfig: {},
       createdBy: 1,
       createdAt: '2026-02-01T00:00:00Z',
+      secondaryProvider: null,
+      secondaryModel: null,
     })
   );
   mockedPromptApi.getRelease.mockResolvedValue(

--- a/frontend2/src/pages/prompt/PromptDetailPage.tsx
+++ b/frontend2/src/pages/prompt/PromptDetailPage.tsx
@@ -837,8 +837,8 @@ function VersionsTab({ promptId }: { promptId: number }) {
                                     isAllowlistLoading ||
                                     isAllowlistError ||
                                     providerModels.length === 0 ||
-                                    (form.secondaryProvider && !form.secondaryModel.trim()) ||
-                                    (form.secondaryProvider && secondaryProviderModels.length === 0)
+                                    !!(form.secondaryProvider && !form.secondaryModel.trim()) ||
+                                    !!(form.secondaryProvider && secondaryProviderModels.length === 0)
                                 }
                                 className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50"
                             >

--- a/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
+++ b/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
@@ -140,15 +140,8 @@ function AddProviderModal({
   provider: string | null;
 }) {
   const [apiKey, setApiKey] = useState('');
-  const [updateError, setUpdateError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const { currentOrgId } = useOrganizationStore();
-
-  const handleClose = () => {
-    setUpdateError(null);
-    setApiKey('');
-    onClose();
-  };
 
   const createMutation = useMutation({
     mutationFn: () => {


### PR DESCRIPTION
* feat: 글로벌 에러 핸들링 및 공통 예외 처리 구조 구축 #6

* feat: add key tables migration #11

* refactor: use Lombok getters in error response #11

* [Feat] 회원가입 기능 및 테스트 기능 구현 완료! #7 (#14)

* feature#7 - implement user singup feature

* feat: signup - complete user service test #7

* feat: complete user signup controller test #7

* feat: signup - url modified #7

* feat: signup - test code modified #7

* feat: signup - Config url modified #7

* EEmail 유효성 조건 추가

* feat: signup - @Email annotation add, Domain name modified(userName > name) #7

* feat: signup - factory method, createdAt field initialize automation, domain name refactoring #7

* feat: signup - enum field name refactoring (LOCKED > DELETED) #7

* Package name refactoring, duplicate email error code modified #7

* feat: signup - method type miss correction #7

* feat : signup - password condition regex refactoring #7

* feat: signup - method type miss correction #7

* feat: signup - User.create() parameter order refactoring #7

* feat: signup - test code modified, some simple method and variable name changed #7

* [Feat] Provider Key 등록 API 구현 #13 (#15)

* feat: add provider key registration #13

* feat: provider-credentials - org scope #13

* refactor: provider-credential validation #13

* chore: clarify AES-GCM IV variable name

---------




* [Feat] Provider Key 목록 조회 API 구현 #17 (#18)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

---------




* feat: organization 및 organizationMember 도메인 구현 (#21)

* Feature/22 provider key aes (#23)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* chore: ignore local .ai folder

* fix: locale-independent provider normalization #22

---------




* Feature/25 organization api key (#26)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* chore: ignore local .ai folder

* fix: locale-independent provider normalization #22

* feat: organization api key create/list #25

* docs: add Javadoc for organization api key flow #25

* refactor: use organizationId params #25

* chore: rename org_id columns #25

---------





* [BE] Workspace(워크스페이스) 생성 및 멤버십 관리 구현 #24 (#28)

* feat: organization 및 organizationMember 도메인 구현

* feat: Workspace 및 WorkspaceMember 도메인 구현

* Feature/27 gateway chat service (#30)

* feat: add provider key registration #13

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* fix: locale-independent provider normalization #22

* feat: organization api key create/list #25

* docs: add Javadoc for organization api key flow #25

* feat: gateway chat service baseline #26

* fix: align provider credential column name

* refactor: align org columns to organization_id

* fix: validate gateway variables

* refactor: avoid transaction during gateway chat

* refactor: add gateway response factory

---------




* [Feat] 워크스페이스 초대 링크 생성 기능 구현 및 스프링부트 버전 다운그레이드 (#32)

* feat: organization 및 organizationMember 도메인 구현

* feat: Workspace 및 WorkspaceMember 도메인 구현

* chore: 스프링부트 버전 다운그레이드

* feat: Workspace 초대 링크 생성 구현

* fix: 오류나는 테스트 일단 주석처리, login관련이라 나중에 변경

* 에러로 인한 health관련 endpoint 변경

* health Test에 SecurityConfig 비활성화

* [Feat] 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링 (#34)

* feat: 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링

* feat: Owner 검증 메서드 추가

* Feature/31 chatoptions provider (#35)

* feat: dynamic provider chat options #31

* chore: align boot 3.5.9 and tests #31

* chore: ignore SpringAI_Overview.md

* refactor: align dto factory naming

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* fix: make gateway chat endpoint provider-agnostic

* refactor: make gateway properties immutable

---------




* Feature/38 t0402 rag documents (#39)

* feat: dynamic provider chat options #31

* chore: align boot 3.5.9 and tests #31

* chore: ignore SpringAI_Overview.md

* refactor: align dto factory naming

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add rag document metadata entity (#36)

* chore: add gateway chat service comments

---------



* [Feat] 조직 목록 조회 및 멤버 퇴출 기능 구현 (#41)

* feat: 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링

* feat: Owner 검증 메서드 추가

* feat: 조직 멤버 조회 및 퇴출 기능 구현

* feat: OrganizationMemberService 내 bulk delete 문제 예방

* FIX :  디벨롭  (#43)

* fix: make gateway chat endpoint provider-agnostic

* refactor: make gateway properties immutable

---------



* [Feat] 로그인 - 로그인 기능 구현 및 테스트 코드 작성 #16 (#20)

* feature#7 - implement user singup feature

* feat: signup - complete user service test #7

* feat: complete user signup controller test #7

* feat: signup - url modified #7

* feat: signup - test code modified #7

* feat: signup - Config url modified #7

* EEmail 유효성 조건 추가

* feat: signup - @Email annotation add, Domain name modified(userName > name) #7

* feat: signup - factory method, createdAt field initialize automation, domain name refactoring #7

* feat: signup - enum field name refactoring (LOCKED > DELETED) #7

* Package name refactoring, duplicate email error code modified #7

* feat: signup - method type miss correction #7

* feat : signup - password condition regex refactoring #7

* feat: signup - method type miss correction #7

* feat: signup - User.create() parameter order refactoring #7

* feat: signup - test code modified, some simple method and variable name changed #7

* package name integration

* feat: login - implement login with JWT authentication

* feat: login - add login success and failure tests

* feat: login - add login config #16

* refactor: User 상태 Enum 변경 (ACTIVATE -> ACTIVE) #16

* feat: 공통 응답 포맷 ApiResponse 추가 #16

* refactor: JwtTokenProvider 생성자 주입 및 Claims 확장 #16

* feat: 토큰 블랙리스트 인터페이스 및 In-Memory 구현 #16

* feat: JWT 인증 필터 및 블랙리스트 검증 로직 구현 #16

* feat: SecurityConfig 필터 등록 및 로그아웃 권한 설정 #16

* feat: 로그인 조직 정보 반영 및 로그아웃 로직 구현 #16

* test: 인증 서비스 및 컨트롤러 테스트 업데이트 #16

* src/main/java/com/llm_ops/demo/auth/controller/AuthController.java

* refactor: User 상태 Enum 변경 (ACTIVATE -> ACTIVE) #16

* test: 로그아웃 통합 테스트 추가 (블랙리스트 검증 포함) #16

* feat: 로그아웃 검증 테스트 및 인증 예외 핸들러 구현 #16

* fix: 로그아웃 테스트(성공:200, 실패 403) 버그 수정 #16

---------



* Feature/40 t0403 문서 텍스트 추출 (#42)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

---------




* feat: Workspace 목록 조회 구현 (#45)

* chore: SecurityConfig 살짝 수정 및 import 변경

* feature: 조직 멤버 역할 변경 구현

* Feature/46 t0404 rag chunking (#47)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* Fix error code for unreadable resources

* Remove duplicate rag.chunking config

---------



* feature/48 T-0405 pgvector 저장 로직 추가 (#49)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* feature/48 T-0405 패키지 누락 수정

* feature/50 T-0406 rag 검색 로직 추가

* feature/48 테스트 프로파일 pgvector 자동설정 제외

---------




* [Feat] 로그인/로그아웃 - Refresh Token 발급 및 Rotation(갱신) 기능 구현 #52 (#55)

* feat: RefreshToken 엔티티 및 Repository 구현- RT 저장을 위한 JPA 엔티티 정의-#52

* feat: RefreshTokenStore 인터페이스 및 JPA 구현체 추가- 저장소 추상화를 위한 Store 패턴 적용 #52

* feat: RefreshTokenService 비즈니스 로직 구현- 토큰 생성(createAndSave) 및 갱신(Rotation) 로직 추가 #52

* feat: RefreshToken 생성 기능 및 JTI 추가 - Refresh Token 만료 시간 설정 로직 추가 #52

* feat: 로그인 시 RT 발급 및 갱신 API 구현- POST /api/v1/auth/refresh 엔드포인트 추가- 로그인 응답에 Refresh Token 포함 #52

* test: RefreshToken 발급 및 RT Rotate 테스트 추가- RT 발급, 갱신(Rotation), 재사용 방지, 로그아웃 검증 테스트 작성 #52

* feat: Refresh Token DTO 추가 및 설정 파일 업데이트 #52

* feat: 토큰 갱신용 DTO 추가 및 프로젝트 설정 파일 마무리 #52

* chore(test): CI 환경을 위한 더미 API 키 설정 추가 #52

* test(auth): AuthServiceTest에 누락된 RefreshTokenService Mock 추가 #52

---------



* [Feat] 내 정보 조회 API(`GET /api/v1/users/me`) 구현, 사용자 관련 로직 패키지 분리(Auth -> User) #56 (#57)

* feat: 내 정보 조회 기능 구현 및 User 패키지 분리 #56

* test: User 통합 테스트 작성 (내 정보 조회) #56

* refactor: AuthController 경로 표준화 (/auth -> /api/v1/auth) #56

* config: Security 허용 경로 업데이트 (/api/v1/auth) #56

* chore: 프로젝트 설정 업데이트 #56

* test: AuthControllerTest API 경로 변경 (/auth -> /api/v1/auth) #56

---------



* feature 58 : S3 업로드 클라이언트 및 MinIO 로컬 테스트 구성 (#60) 

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* Add S3 client with MinIO local support

* fix: add s3 upload logging #58

---------



* [Refactor] 컨트롤러에 있던 x-user-id를@AuthenticationPrincipal으로 전환 (#63)

* refactor: 컨트롤러에 있던 x-user-id를@AuthenticationPrincipal으로 전환

* fix: 테스트용 config와 filter 생성 및 통합테스트용 프로필 생성

* [Feat] Prompt CRUD 기능 구현 (#61)

* feat: prompt CRUD 기능 구현

* feat: prompt crud 테스트 코드 구현

* fix: Dto에 있는 정규표현식 버그 수정

* feat: promptkey 수정시 빈 문자열 허용 불가로 변경 및 엔드포인트 변경

* Feature/64 t0402 문서 메타데이터 저장/조회/삭제 서비스 구현 (#65)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* refactor(#64): make RagDocument markDeleted idempotent

* refactor(#64): simplify rag document services and validate fileUrl prefix

---------




* [Feat] #66 RAG 벡터 저장 파이프라인 연결 (#67)

* feat: rag ingest pipeline service #66

* refactor(#66): address rag ingest review comments

---------




* [Feat] rag controller (#69)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* fix: validate rag search access and inputs

* refactor: add rag facade and method validation

* fix: validate rag access ids

* chore: align rag ingest with develop

* fix: guard rag controller and h2 jsonb

* test: wire vectorstore for rag ingest

* fix: validate rag ids at controller

* test: add vectorstore stubs

* refactor: use authentication principal in rag controller

---------



* [Feat] 문서 API (업로드/리스트/삭제) + multipart 지원 #70 (#71)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* feat: document api upload/list/delete #70

* refactor(#70): apply PR feedback - add workspace validation and improve error handling

- Add workspace access validation to all document endpoints
  - Validate user membership before document operations
  - Prevent cross-tenant document access (security fix)

- Improve file upload error handling
  - Add S3 cleanup on DB save failure (compensation transaction)
  - Extract file validation to separate method

- Update delete endpoint
  - Add workspaceId path parameter
  - Use workspace-scoped delete method

- Apply code conventions
  - Add @RequiredArgsConstructor to RagDocumentVectorStoreDeleteService
  - Add SQL injection protection for schema/table names

Resolves security vulnerability and addresses all PR review comments

* refactor: centralize workspace access validation

* test: stabilize gateway integration tests

* fix: harden rag document lifecycle

* refactor: use authentication principal in rag controllers

* Fix RagControllerTest authentication principal

---------



* [Feat] Prompt 버전 관리 기능 구현 (#78)

* feature: prompt 버전 관리 기능 구현

* trigger coderabbit

* [Feat] Prompt version dto필드명 프론트엔드와 통합 (#81)

* feature: prompt 버전 관리 기능 구현

* trigger coderabbit

* feat: dto 필드명 프론트와 맞추게 변경

* feat: test코드도 변경에 맞춰서 수정

* chore: frontend파일 공유 (#84)

* [Feat] RAG 검색 응답에 documentId 추가 #73 (#74)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* feat: document api upload/list/delete #70

* feat: add documentId to rag search response #73

* refactor(#70): apply PR feedback - add workspace validation and improve error handling

- Add workspace access validation to all document endpoints
  - Validate user membership before document operations
  - Prevent cross-tenant document access (security fix)

- Improve file upload error handling
  - Add S3 cleanup on DB save failure (compensation transaction)
  - Extract file validation to separate method

- Update delete endpoint
  - Add workspaceId path parameter
  - Use workspace-scoped delete method

- Apply code conventions
  - Add @RequiredArgsConstructor to RagDocumentVectorStoreDeleteService
  - Add SQL injection protection for schema/table names

Resolves security vulnerability and addresses all PR review comments

* refactor: centralize workspace access validation

* test: stabilize gateway integration tests

* fix: harden rag document lifecycle

* refactor: use authentication principal in rag controllers

* feat: propagate documentName into rag chunks

* fix: align rag ingest tests and validations

* refactor: simplify document delete flow

* Add deleting state to document deletion flow

---------




* feat: 프론트엔드 1차 구현 (#92)



* [Feat]  Gateway RAG 연동 지원 및 테스트 강화 (#82)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

---------




* feat: prompt release 기능 구현 (#83)

* [Feat] Prompt 롤백 기능 구현 (#86)

* feat: prompt release 기능 구현

* feat: prompt rollback 기능 구현

* Feature/87 flyway request logs schema chain (#93)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

---------




* Feature/89 request log entity chain (#94)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* Harden request log lifecycle and org constraint

* fix(test): update request log writer start args

---------




* Feature/95 traceid requestid propagation (#96)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* Harden request log lifecycle and org constraint

* fix(test): update request log writer start args

* fix(gateway): include api key context in request logs

---------




* Feature/97 gateway success logging (#98)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

---------



* Feature/99 gateway fail logging (#100)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

---------



* Feature/101 rag metrics logging (#102)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

---------



* Feature/103 api key tracking (#104)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

* feat(logging): track api key id/prefix in request logs (#103)

---------



* Feature/frontend jiwoo (#105)

* feat(logging): persist rag metrics for request logs (#101)

* feat(frontend): org-scoped routing and provider status

* feat(gateway): use prompt release for provider/model

* feat(frontend): prompt version/release UX

* fix(prompt): persist prompt release safely

* feat(frontend): org-scoped workspaces

* feat(org): enforce single-organization membership

* feat(org): add organization detail endpoint

* fix(auth): allow gateway chat without login

* chore(db): make migrations idempotent

* feat(rag): track document ingest status

* feat(frontend): show RAG document statuses

* fix(test): align gateway and document tests

* fix(gateway): eager-load prompt release version

* feat(prompt): add model allowlist config

* feat(prompt): add model allowlist properties

* feat(prompt): add allowlist API

* feat(prompt): validate models on version create

* refactor(prompt): drop redundant getters

* feat(frontend): add model allowlist UI

* fix(frontend): guard workspace routes

* fix(frontend): guard invite navigation

---------



* feat: API key 재발급 기능 구현 및 코드 중복 리팩토링 (#107)

* [Feat] 로그 - Entity, Repository 로직 수정 리팩토링 및  테스트 코드 작성 #108 (#109)

* feat : log -비동기 로그 저장을 위한 AsyncConfig 추가  #108

* feat : log - 필수 필드 null 검증 추가 (fail-fast) #108

* feat:log - 로그 저장 비동기 처리 및 에러 핸들링 개선  #108

* chore:log -레거시 코드 주석 처리 (추후 삭제 예정)  #108

* test:log - @Async 비동기 처리 테스트 호환성 확보  #108

---------



* [Feat] 로그 - 조회 API 및 테스트 코드 구현 #110 (#112)

* feat : log -비동기 로그 저장을 위한 AsyncConfig 추가  #108

* feat : log - 필수 필드 null 검증 추가 (fail-fast) #108

* feat:log - 로그 저장 비동기 처리 및 에러 핸들링 개선  #108

* chore:log -레거시 코드 주석 처리 (추후 삭제 예정)  #108

* test:log - @Async 비동기 처리 테스트 호환성 확보  #108

* feat : log - 로그 검색 조건 DTO 추가 #110

* feat : log - 로그 응답 DTO 추가 #110

* feat : log - 페이징 응답 DTO 추가 #110

* feat : log - 동적 쿼리 조건 Specification 추가 #110

* feat : log - JpaSpecificationExecutor 확장 및 워크스페이스별 조회 메서드 추가 #110

* feat : log - 로그 조회 서비스 구현 #110

* feat : log - 로그 조회 API 엔드포인트 구현 #110

* test : log - 로그 조회 서비스 테스트 추가 #110

* Feat: 로그 조회 API 권한 검증 추가 및 테스트 구현
- RequestLogController: WorkspaceAccessService를 통한 멤버십 검증 로직 추가
- RequestLogControllerTest: 권한 없는 접근에 대한 403 Forbidden 응답 검증 테스트 추가
- DateTimeFormat 적용으로 파라미터 바인딩 안정성 확보 #110

* Fix: 로그 검색 조건 Null Pointer Exception 방어 로직 추가

- 검색 조건(condition)이 null일 경우 빈 조건 객체로 대체하여 NPE 방지 #110

* Test: 로그 조회 서비스 필터 테스트 추가 및 리팩토링

- 다양한 필터 조건(날짜, 복합 조건, null)에 대한 테스트 케이스 추가
- 테스트 데이터 격리를 위한 workspaceId 상수화 및 헬퍼 메서드 개선 #110

* Refactor: RequestLogControllerTest @MockBean -> @MockitoBean 교체 #110

* [Feat] 프론트엔드 통계 mock ui 작업 및 로그아웃 끊기지 않게 설정 (#111)

* 통계 mock ui 작업 및 로그아웃 끊기지 않게 설정

* PromptReleaseTest 오류 해결

* fix: minIO 환경변수 설정

* fix: minIO 환경변수 테스트 설정

* 통계 관련 api 기능 구현 및 프론트와 연동 (#114)

* fix: 비용 계산 로직 서비스로 이동 및 멤버 삭제 버그 수정

* fix: 테스트 코드 변경

* fix: 조직 전환 시 잘못된 워크스페이스 id로 인한 잘못된 초대 생성 방지

* fix: 음수 비용 방지 방어적 프로그래밍

* fix: 프로바이더가 입출력토큰을 반환하지 않을 때 비용 계산 null로 프론트엔드에게 반환

* fix(statistics): PERCENTILE_CONT 지원을 위한 nativeQuery 적용 및 시계열 쿼리 분리 #119

* fix(statistics): 시계열 API에 period 기반 쿼리 분기 로직 추가 #119

* Feature/workspace fix (#118)

* feat(gateway): use prompt release for provider/model

* fix(prompt): persist prompt release safely

* fix(gateway): support single-brace variables

* feat(frontend): org-scoped routing and provider status

* feat(frontend): prompt version/release UX

* fix(test): align gateway and document tests

* refactor(prompt): drop redundant getters

* feat(frontend): add model allowlist UI

* Add user and organization id getters

* Expose api key and workspace identifiers

* Expose error status accessor

* Add rag and failover fields to prompt versions

* Expose prompt release history details

* Expose prompt workspace and key

* Wire prompt release accessors and service

* Expand prompt version request and response fields

* Validate prompt version inputs and failover

* Add workspace rag settings schema

* Implement workspace rag settings service

* Add workspace rag settings endpoint

* Expose rag search and context defaults

* Allow rag search overrides per request

* feat(db): add initial schema migration V1

- Add base tables: console_user, organizations, workspaces
- Add member management: organization_members, workspace_members
- Add workspace invitation links and refresh tokens
- Add documents table with status constraints
- Establish foreign key relationships for data integrity

* fix(frontend): remove duplicate import in PromptEntryPage

- Remove duplicate 'useEffect, useMemo' import from react
- Resolves import conflict from cherry-pick merge

* feat(rag): add document preview endpoint with chunk sampling

* feat(storage): add S3 document download methods

* feat(gateway): use configurable RAG settings in chat service

* feat(api): add RAG settings API client

* feat(document): add document preview modal and RAG settings UI

* feat(prompt): enhance version management and add new type definitions

* refactor(dashboard): update quick actions and add provider key check

* fix(ui): minor text and styling updates in login and settings

* test: update tests for RAG settings integration

* feat(keys): add provider credential update API

* feat(frontend): enable provider key updates

* fix(rag): avoid preview service without S3

* feat: update frontend2 prompt version types and UI; backend GatewayChatService failover logic

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* test: fix GatewayChatServiceUnitTest for RAG settings and reflection signature

* feat(frontend): UI tweaks for login, prompt detail, and settings

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(auth): introduce RefreshToken domain, repository, and service

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(auth): add token storage interfaces (JPA store and token store)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(rag/gateway): wire GatewayChatService, RagController, RagDocumentPreviewService

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(rag): add S3ApiClient and Rag workspace settings DTOs

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(db): initial schema migration and AuthService test updates

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)



* feat(auth): add new authentication utility

---------




* fix: statistics - 이전 기간 계산 시 현재 기간과 동일한 길이로 설정 #119

* fix(statistics): successCount/errorCount에 COALESCE 적용하여 NPE 방지 #119

* [Fix] 프롬프트 버전, 배포 이력에서 생성한 사람 이름 표시 (#122)

* fix: 프롬프트 버전, 배포 이력에서 생성한 사람 이름 표시

* feat: fetch join으로 n+1 문제 해결

* [Feat] 프론트엔드에서 api key 재발급 버튼 표시 구현 (#123)

* feat: 프론트엔드에서 api key 재발급 버튼 표시 구현

* feat: 모달 컴포넌트에 key prop 추가로 상태 초기화 구현

* feat: api key 재발급 오류 시 에러 처리 구현

* feat: api key 재발급 시 제목 올바르게 표시

* chore(security): configure CORS allow-origin 5174 and allowed headers (#124)





* fix(provider-key-update-modal): initialize updateError and handleClose state to fix black screen on SettingsProviderKeysPage (#125)



* [Feat] 워크스페이스 수정 api 구현 및 프론트 연동 (#126)

* feat: 워크스페이스 수정 api 구현 및 프론트 연동

* feat: 백엔드 dto와 통일성을 위해 updatedAt 삭제

* [Feat] 워크스페이스 삭제 api 구현 및 프론트엔드 연동 (#127)

* feat: 워크스페이스 수정 api 구현 및 프론트 연동

* feat: 백엔드 dto와 통일성을 위해 updatedAt 삭제

* feat: 백엔드 워크스페이스 api 구현

* feat: 프론트엔드 워크스페이스 삭제 구현

* feat: inactive 상태의 워크스페이스 목록 조회 시 보이지 않게 수정

* fix: WorkspaceControllerTest 불필요한 import 제거

* 배포용 환경변수 설정 (#130)

* 배포용 환경변수 설정

* docker file 백슬래시 추가

* Deploy/final check (#133)



* [Fix] sync main to develop (#139)

* Deploy/final v2 (#134)

* feat: 글로벌 에러 핸들링 및 공통 예외 처리 구조 구축 #6

* feat: add key tables migration #11

* refactor: use Lombok getters in error response #11

* [Feat] 회원가입 기능 및 테스트 기능 구현 완료! #7 (#14)

* feature#7 - implement user singup feature

* feat: signup - complete user service test #7

* feat: complete user signup controller test #7

* feat: signup - url modified #7

* feat: signup - test code modified #7

* feat: signup - Config url modified #7

* EEmail 유효성 조건 추가

* feat: signup - @Email annotation add, Domain name modified(userName > name) #7

* feat: signup - factory method, createdAt field initialize automation, domain name refactoring #7

* feat: signup - enum field name refactoring (LOCKED > DELETED) #7

* Package name refactoring, duplicate email error code modified #7

* feat: signup - method type miss correction #7

* feat : signup - password condition regex refactoring #7

* feat: signup - method type miss correction #7

* feat: signup - User.create() parameter order refactoring #7

* feat: signup - test code modified, some simple method and variable name changed #7

* [Feat] Provider Key 등록 API 구현 #13 (#15)

* feat: add provider key registration #13

* feat: provider-credentials - org scope #13

* refactor: provider-credential validation #13

* chore: clarify AES-GCM IV variable name

---------




* [Feat] Provider Key 목록 조회 API 구현 #17 (#18)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

---------




* feat: organization 및 organizationMember 도메인 구현 (#21)

* Feature/22 provider key aes (#23)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* chore: ignore local .ai folder

* fix: locale-independent provider normalization #22

---------




* Feature/25 organization api key (#26)

* feat: add provider key registration #13

* feat: add provider key list #17

* feat: organization-scoped provider credentials

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* chore: ignore local .ai folder

* fix: locale-independent provider normalization #22

* feat: organization api key create/list #25

* docs: add Javadoc for organization api key flow #25

* refactor: use organizationId params #25

* chore: rename org_id columns #25

---------





* [BE] Workspace(워크스페이스) 생성 및 멤버십 관리 구현 #24 (#28)

* feat: organization 및 organizationMember 도메인 구현

* feat: Workspace 및 WorkspaceMember 도메인 구현

* Feature/27 gateway chat service (#30)

* feat: add provider key registration #13

* fix: align provider credential service with org-scoped DTOs

* feat: provider key decrypt for internal use #22

* fix: locale-independent provider normalization #22

* feat: organization api key create/list #25

* docs: add Javadoc for organization api key flow #25

* feat: gateway chat service baseline #26

* fix: align provider credential column name

* refactor: align org columns to organization_id

* fix: validate gateway variables

* refactor: avoid transaction during gateway chat

* refactor: add gateway response factory

---------




* [Feat] 워크스페이스 초대 링크 생성 기능 구현 및 스프링부트 버전 다운그레이드 (#32)

* feat: organization 및 organizationMember 도메인 구현

* feat: Workspace 및 WorkspaceMember 도메인 구현

* chore: 스프링부트 버전 다운그레이드

* feat: Workspace 초대 링크 생성 구현

* fix: 오류나는 테스트 일단 주석처리, login관련이라 나중에 변경

* 에러로 인한 health관련 endpoint 변경

* health Test에 SecurityConfig 비활성화

* [Feat] 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링 (#34)

* feat: 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링

* feat: Owner 검증 메서드 추가

* Feature/31 chatoptions provider (#35)

* feat: dynamic provider chat options #31

* chore: align boot 3.5.9 and tests #31

* chore: ignore SpringAI_Overview.md

* refactor: align dto factory naming

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* fix: make gateway chat endpoint provider-agnostic

* refactor: make gateway properties immutable

---------




* Feature/38 t0402 rag documents (#39)

* feat: dynamic provider chat options #31

* chore: align boot 3.5.9 and tests #31

* chore: ignore SpringAI_Overview.md

* refactor: align dto factory naming

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add rag document metadata entity (#36)

* chore: add gateway chat service comments

---------



* [Feat] 조직 목록 조회 및 멤버 퇴출 기능 구현 (#41)

* feat: 워크스페이스 초대 수락 구현 및 초대 관련 코드 리팩토링

* feat: Owner 검증 메서드 추가

* feat: 조직 멤버 조회 및 퇴출 기능 구현

* feat: OrganizationMemberService 내 bulk delete 문제 예방

* FIX :  디벨롭  (#43)

* fix: make gateway chat endpoint provider-agnostic

* refactor: make gateway properties immutable

---------



* [Feat] 로그인 - 로그인 기능 구현 및 테스트 코드 작성 #16 (#20)

* feature#7 - implement user singup feature

* feat: signup - complete user service test #7

* feat: complete user signup controller test #7

* feat: signup - url modified #7

* feat: signup - test code modified #7

* feat: signup - Config url modified #7

* EEmail 유효성 조건 추가

* feat: signup - @Email annotation add, Domain name modified(userName > name) #7

* feat: signup - factory method, createdAt field initialize automation, domain name refactoring #7

* feat: signup - enum field name refactoring (LOCKED > DELETED) #7

* Package name refactoring, duplicate email error code modified #7

* feat: signup - method type miss correction #7

* feat : signup - password condition regex refactoring #7

* feat: signup - method type miss correction #7

* feat: signup - User.create() parameter order refactoring #7

* feat: signup - test code modified, some simple method and variable name changed #7

* package name integration

* feat: login - implement login with JWT authentication

* feat: login - add login success and failure tests

* feat: login - add login config #16

* refactor: User 상태 Enum 변경 (ACTIVATE -> ACTIVE) #16

* feat: 공통 응답 포맷 ApiResponse 추가 #16

* refactor: JwtTokenProvider 생성자 주입 및 Claims 확장 #16

* feat: 토큰 블랙리스트 인터페이스 및 In-Memory 구현 #16

* feat: JWT 인증 필터 및 블랙리스트 검증 로직 구현 #16

* feat: SecurityConfig 필터 등록 및 로그아웃 권한 설정 #16

* feat: 로그인 조직 정보 반영 및 로그아웃 로직 구현 #16

* test: 인증 서비스 및 컨트롤러 테스트 업데이트 #16

* src/main/java/com/llm_ops/demo/auth/controller/AuthController.java

* refactor: User 상태 Enum 변경 (ACTIVATE -> ACTIVE) #16

* test: 로그아웃 통합 테스트 추가 (블랙리스트 검증 포함) #16

* feat: 로그아웃 검증 테스트 및 인증 예외 핸들러 구현 #16

* fix: 로그아웃 테스트(성공:200, 실패 403) 버그 수정 #16

---------



* Feature/40 t0403 문서 텍스트 추출 (#42)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

---------




* feat: Workspace 목록 조회 구현 (#45)

* chore: SecurityConfig 살짝 수정 및 import 변경

* feature: 조직 멤버 역할 변경 구현

* Feature/46 t0404 rag chunking (#47)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* Fix error code for unreadable resources

* Remove duplicate rag.chunking config

---------



* feature/48 T-0405 pgvector 저장 로직 추가 (#49)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* feature/48 T-0405 패키지 누락 수정

* feature/50 T-0406 rag 검색 로직 추가

* feature/48 테스트 프로파일 pgvector 자동설정 제외

---------




* [Feat] 로그인/로그아웃 - Refresh Token 발급 및 Rotation(갱신) 기능 구현 #52 (#55)

* feat: RefreshToken 엔티티 및 Repository 구현- RT 저장을 위한 JPA 엔티티 정의-#52

* feat: RefreshTokenStore 인터페이스 및 JPA 구현체 추가- 저장소 추상화를 위한 Store 패턴 적용 #52

* feat: RefreshTokenService 비즈니스 로직 구현- 토큰 생성(createAndSave) 및 갱신(Rotation) 로직 추가 #52

* feat: RefreshToken 생성 기능 및 JTI 추가 - Refresh Token 만료 시간 설정 로직 추가 #52

* feat: 로그인 시 RT 발급 및 갱신 API 구현- POST /api/v1/auth/refresh 엔드포인트 추가- 로그인 응답에 Refresh Token 포함 #52

* test: RefreshToken 발급 및 RT Rotate 테스트 추가- RT 발급, 갱신(Rotation), 재사용 방지, 로그아웃 검증 테스트 작성 #52

* feat: Refresh Token DTO 추가 및 설정 파일 업데이트 #52

* feat: 토큰 갱신용 DTO 추가 및 프로젝트 설정 파일 마무리 #52

* chore(test): CI 환경을 위한 더미 API 키 설정 추가 #52

* test(auth): AuthServiceTest에 누락된 RefreshTokenService Mock 추가 #52

---------



* [Feat] 내 정보 조회 API(`GET /api/v1/users/me`) 구현, 사용자 관련 로직 패키지 분리(Auth -> User) #56 (#57)

* feat: 내 정보 조회 기능 구현 및 User 패키지 분리 #56

* test: User 통합 테스트 작성 (내 정보 조회) #56

* refactor: AuthController 경로 표준화 (/auth -> /api/v1/auth) #56

* config: Security 허용 경로 업데이트 (/api/v1/auth) #56

* chore: 프로젝트 설정 업데이트 #56

* test: AuthControllerTest API 경로 변경 (/auth -> /api/v1/auth) #56

---------



* feature 58 : S3 업로드 클라이언트 및 MinIO 로컬 테스트 구성 (#60) 

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* Add S3 client with MinIO local support

* fix: add s3 upload logging #58

---------



* [Refactor] 컨트롤러에 있던 x-user-id를@AuthenticationPrincipal으로 전환 (#63)

* refactor: 컨트롤러에 있던 x-user-id를@AuthenticationPrincipal으로 전환

* fix: 테스트용 config와 filter 생성 및 통합테스트용 프로필 생성

* [Feat] Prompt CRUD 기능 구현 (#61)

* feat: prompt CRUD 기능 구현

* feat: prompt crud 테스트 코드 구현

* fix: Dto에 있는 정규표현식 버그 수정

* feat: promptkey 수정시 빈 문자열 허용 불가로 변경 및 엔드포인트 변경

* Feature/64 t0402 문서 메타데이터 저장/조회/삭제 서비스 구현 (#65)

* feat: dynamic provider chat options #31

* feat: enhance gateway provider routing and local testing

* fix: align openai chat model wiring for tests

* feat: add tika document extraction service (#40)

* fix: qualify openai chat model injection

* feat(#46): add RAG token chunking

* feature/48 T-0405 pgvector 저장 로직 추가

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* refactor(#64): make RagDocument markDeleted idempotent

* refactor(#64): simplify rag document services and validate fileUrl prefix

---------




* [Feat] #66 RAG 벡터 저장 파이프라인 연결 (#67)

* feat: rag ingest pipeline service #66

* refactor(#66): address rag ingest review comments

---------




* [Feat] rag controller (#69)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* fix: validate rag search access and inputs

* refactor: add rag facade and method validation

* fix: validate rag access ids

* chore: align rag ingest with develop

* fix: guard rag controller and h2 jsonb

* test: wire vectorstore for rag ingest

* fix: validate rag ids at controller

* test: add vectorstore stubs

* refactor: use authentication principal in rag controller

---------



* [Feat] 문서 API (업로드/리스트/삭제) + multipart 지원 #70 (#71)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* feat: document api upload/list/delete #70

* refactor(#70): apply PR feedback - add workspace validation and improve error handling

- Add workspace access validation to all document endpoints
  - Validate user membership before document operations
  - Prevent cross-tenant document access (security fix)

- Improve file upload error handling
  - Add S3 cleanup on DB save failure (compensation transaction)
  - Extract file validation to separate method

- Update delete endpoint
  - Add workspaceId path parameter
  - Use workspace-scoped delete method

- Apply code conventions
  - Add @RequiredArgsConstructor to RagDocumentVectorStoreDeleteService
  - Add SQL injection protection for schema/table names

Resolves security vulnerability and addresses all PR review comments

* refactor: centralize workspace access validation

* test: stabilize gateway integration tests

* fix: harden rag document lifecycle

* refactor: use authentication principal in rag controllers

* Fix RagControllerTest authentication principal

---------



* [Feat] Prompt 버전 관리 기능 구현 (#78)

* feature: prompt 버전 관리 기능 구현

* trigger coderabbit

* [Feat] Prompt version dto필드명 프론트엔드와 통합 (#81)

* feature: prompt 버전 관리 기능 구현

* trigger coderabbit

* feat: dto 필드명 프론트와 맞추게 변경

* feat: test코드도 변경에 맞춰서 수정

* chore: frontend파일 공유 (#84)

* [Feat] RAG 검색 응답에 documentId 추가 #73 (#74)

* feat: rag ingest pipeline service #66

* feat: rag search controller #68

* fix: guard rag controller bean #68

* fix: stabilize rag controller tests #68

* Add S3 client with MinIO local support

* feat(#64): add rag document metadata services

* feat: document api upload/list/delete #70

* feat: add documentId to rag search response #73

* refactor(#70): apply PR feedback - add workspace validation and improve error handling

- Add workspace access validation to all document endpoints
  - Validate user membership before document operations
  - Prevent cross-tenant document access (security fix)

- Improve file upload error handling
  - Add S3 cleanup on DB save failure (compensation transaction)
  - Extract file validation to separate method

- Update delete endpoint
  - Add workspaceId path parameter
  - Use workspace-scoped delete method

- Apply code conventions
  - Add @RequiredArgsConstructor to RagDocumentVectorStoreDeleteService
  - Add SQL injection protection for schema/table names

Resolves security vulnerability and addresses all PR review comments

* refactor: centralize workspace access validation

* test: stabilize gateway integration tests

* fix: harden rag document lifecycle

* refactor: use authentication principal in rag controllers

* feat: propagate documentName into rag chunks

* fix: align rag ingest tests and validations

* refactor: simplify document delete flow

* Add deleting state to document deletion flow

---------




* feat: 프론트엔드 1차 구현 (#92)



* [Feat]  Gateway RAG 연동 지원 및 테스트 강화 (#82)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

---------




* feat: prompt release 기능 구현 (#83)

* [Feat] Prompt 롤백 기능 구현 (#86)

* feat: prompt release 기능 구현

* feat: prompt rollback 기능 구현

* Feature/87 flyway request logs schema chain (#93)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

---------




* Feature/89 request log entity chain (#94)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* Harden request log lifecycle and org constraint

* fix(test): update request log writer start args

---------




* Feature/95 traceid requestid propagation (#96)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* Harden request log lifecycle and org constraint

* fix(test): update request log writer start args

* fix(gateway): include api key context in request logs

---------




* Feature/97 gateway success logging (#98)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

---------



* Feature/99 gateway fail logging (#100)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

---------



* Feature/101 rag metrics logging (#102)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

---------



* Feature/103 api key tracking (#104)

* Update gateway RAG integration tests

* Validate workspace ownership for RAG

* Assert RAG query in gateway integration tests

* Limit RAG context size in gateway

* Fix ChunkDetailResponse test data

* feat(infra): Flyway 도입 및 request_logs v1 스키마 추가 (#87)

- build.gradle에 Flyway 의존성 추가 (flyway-core, flyway-database-postgresql)
- application.yml에 Flyway 설정 추가 (baseline-on-migrate, locations)
- application-test.yml에서 Flyway 비활성화 (H2 호환성)
- V7__request_logs.sql 마이그레이션 추가
  - 게이트웨이 요청 로그 테이블 (1요청 1행)
  - 테넌트/프롬프트/모델/토큰/비용/RAG 관측 컬럼
  - 대시보드/조회용 인덱스 5개

* feat(logging): add request log entity/repo/writer (#89)

* feat(logging): fix traceId at gateway entry (#95)

* feat(logging): mark gateway request log success (#97)

* feat(logging): mark gateway request log fail (#99)

* feat(logging): persist rag metrics for request logs (#101)

* feat(logging): track api key id/prefix in request logs (#103)

---------



* Feature/frontend jiwoo (#105)

* feat(logging): persist rag metrics for request logs (#101)

* feat(frontend): org-scoped routing and provider status

* feat(gateway): use prompt release for provider/model

* feat(frontend): prompt version/release UX

* fix(prompt): persist prompt release safely

* feat(frontend): org-scoped workspaces

* feat(org): enforce single-organization membership

* feat…

## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용
- 어떤 기능을 구현했는지 혹은 어떤 문제를 해결했는지 적어주세요.
- 주요 변경 사항을 요약해주세요.

## 📸 스크린샷 (선택)
- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부해주세요.

## 📚 레퍼런스 (선택)
- 참고한 링크나 문서가 있다면 적어주세요.

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 데이터에 보조 제공자 관련 필드 추가

* **Refactor**
  * 설정 페이지의 제공자 키 모달 로직 간소화
  * 조건 검사 로직 개선으로 코드 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->