### PR TITLE
feat(provider-key): verify provider key on save/update and show succe…

### DIFF
--- a/frontend2/src/pages/prompt/PromptDetailPage.test.tsx
+++ b/frontend2/src/pages/prompt/PromptDetailPage.test.tsx
@@ -80,13 +80,13 @@ beforeEach(() => {
       title: 'v1',
       provider: 'OPENAI',
       model: 'gpt-4o-mini',
+      secondaryProvider: null,
+      secondaryModel: null,
       systemPrompt: 'system',
       userTemplate: '질문: {{question}}',
       modelConfig: {},
       createdBy: 1,
       createdAt: '2026-02-01T00:00:00Z',
-      secondaryProvider: null,
-      secondaryModel: null,
     })
   );
   mockedPromptApi.getRelease.mockResolvedValue(

--- a/frontend2/src/pages/prompt/PromptDetailPage.tsx
+++ b/frontend2/src/pages/prompt/PromptDetailPage.tsx
@@ -827,23 +827,23 @@ function VersionsTab({ promptId }: { promptId: number }) {
                             >
                                 취소
                             </button>
-                            <button
-                                onClick={() => createMutation.mutate()}
-                                disabled={
-                                    !form.model.trim() ||
-                                    !isTemplateValid ||
-                                    createMutation.isPending ||
-                                    availableProviders.length === 0 ||
-                                    isAllowlistLoading ||
-                                    isAllowlistError ||
-                                    providerModels.length === 0 ||
-                                    !!(form.secondaryProvider && !form.secondaryModel.trim()) ||
-                                    !!(form.secondaryProvider && secondaryProviderModels.length === 0)
-                                }
-                                className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50"
-                            >
-                                {createMutation.isPending ? '생성 중...' : '버전 생성'}
-                            </button>
+	                            <button
+	                                onClick={() => createMutation.mutate()}
+	                                disabled={
+	                                    !form.model.trim() ||
+	                                    !isTemplateValid ||
+	                                    createMutation.isPending ||
+	                                    availableProviders.length === 0 ||
+	                                    isAllowlistLoading ||
+	                                    isAllowlistError ||
+	                                    providerModels.length === 0 ||
+	                                    (!!form.secondaryProvider && !form.secondaryModel.trim()) ||
+	                                    (!!form.secondaryProvider && secondaryProviderModels.length === 0)
+	                                }
+	                                className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50"
+	                            >
+	                                {createMutation.isPending ? '생성 중...' : '버전 생성'}
+	                            </button>
                         </div>
                     </div>
                 </div>

--- a/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
+++ b/frontend2/src/pages/settings/SettingsProviderKeysPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { AxiosError } from 'axios';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { organizationApi } from '@/api/organization.api';
 import { useOrganizationStore } from '@/features/organization/store/organizationStore';
@@ -36,6 +37,14 @@ const normalizeProviderKey = (raw: string) => {
   if (normalized === 'google') return 'GEMINI';
   if (normalized === 'claude') return 'ANTHROPIC';
   return normalized.toUpperCase();
+};
+
+const resolveCredentialError = (error: unknown, fallback: string) => {
+  if (!error) {
+    return fallback;
+  }
+  const axiosError = error as AxiosError<{ message?: string }>;
+  return axiosError.response?.data?.message || fallback;
 };
 
 function ProviderCard({
@@ -134,14 +143,23 @@ function AddProviderModal({
   isOpen,
   onClose,
   provider,
+  onSuccessMessage,
 }: {
   isOpen: boolean;
   onClose: () => void;
   provider: string | null;
+  onSuccessMessage: (message: string) => void;
 }) {
   const [apiKey, setApiKey] = useState('');
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const { currentOrgId } = useOrganizationStore();
+
+  const handleClose = () => {
+    setUpdateError(null);
+    setApiKey('');
+    onClose();
+  };
 
   const createMutation = useMutation({
     mutationFn: () => {
@@ -153,8 +171,13 @@ function AddProviderModal({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['provider-credentials', currentOrgId] });
+      setUpdateError(null);
       setApiKey('');
-      onClose();
+      onSuccessMessage('검증 완료 - API 키가 저장되었습니다.');
+      handleClose();
+    },
+    onError: (error) => {
+      setUpdateError(resolveCredentialError(error, 'API 키 검증에 실패했습니다.'));
     },
   });
 
@@ -166,7 +189,7 @@ function AddProviderModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
+        onClick={handleClose}
       />
       <div className="relative w-full max-w-md mx-4 p-6 bg-white rounded-xl shadow-xl border border-gray-100">
         <div className="flex items-center gap-4 mb-6">
@@ -190,7 +213,10 @@ function AddProviderModal({
           <input
             type="password"
             value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
+            onChange={(e) => {
+              setApiKey(e.target.value);
+              if (updateError) setUpdateError(null);
+            }}
             placeholder={`sk-... (${info?.name} API Key)`}
             className="w-full px-4 py-3 text-sm text-gray-900 bg-gray-50 border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent outline-none transition-all font-mono"
             autoFocus
@@ -199,11 +225,14 @@ function AddProviderModal({
             <Shield size={12} />
             키는 서버에 암호화되어 저장되며 클라이언트에 노출되지 않습니다.
           </p>
+          {updateError && (
+            <p className="mt-2 text-xs text-rose-600">{updateError}</p>
+          )}
         </div>
 
         <div className="flex gap-3">
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
           >
             취소
@@ -213,7 +242,7 @@ function AddProviderModal({
             disabled={!apiKey.trim() || createMutation.isPending}
             className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 shadow-sm"
           >
-            {createMutation.isPending ? '연결 중...' : '연결하기'}
+            {createMutation.isPending ? '검증 중...' : '연결 및 검증'}
           </button>
         </div>
       </div>
@@ -225,10 +254,12 @@ function UpdateProviderModal({
   isOpen,
   onClose,
   credential,
+  onSuccessMessage,
 }: {
   isOpen: boolean;
   onClose: () => void;
   credential: ProviderCredentialSummaryResponse | null;
+  onSuccessMessage: (message: string) => void;
 }) {
   const [apiKey, setApiKey] = useState('');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -250,11 +281,11 @@ function UpdateProviderModal({
       queryClient.invalidateQueries({ queryKey: ['provider-credentials', currentOrgId] });
       setUpdateError(null);
       setApiKey('');
+      onSuccessMessage('검증 완료 - API 키가 업데이트되었습니다.');
       onClose();
     },
     onError: (error) => {
-      const message = error instanceof Error ? error.message : 'API 키 업데이트에 실패했습니다.';
-      setUpdateError(message);
+      setUpdateError(resolveCredentialError(error, 'API 키 검증에 실패했습니다.'));
     },
   });
 
@@ -319,7 +350,7 @@ function UpdateProviderModal({
             disabled={!apiKey.trim() || updateMutation.isPending}
             className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors disabled:opacity-50 shadow-sm"
           >
-            {updateMutation.isPending ? '업데이트 중...' : '업데이트'}
+            {updateMutation.isPending ? '검증 중...' : '업데이트 및 검증'}
           </button>
         </div>
       </div>
@@ -330,7 +361,28 @@ function UpdateProviderModal({
 export function SettingsProviderKeysPage() {
   const [addingProvider, setAddingProvider] = useState<string | null>(null);
   const [updatingCredential, setUpdatingCredential] = useState<ProviderCredentialSummaryResponse | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const toastTimerRef = useRef<number | null>(null);
   const { currentOrgId } = useOrganizationStore();
+
+  const showToast = (message: string) => {
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current);
+    }
+    setToastMessage(message);
+    toastTimerRef.current = window.setTimeout(() => {
+      setToastMessage(null);
+      toastTimerRef.current = null;
+    }, 2000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        window.clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
 
   const { data: credentials, isLoading } = useQuery({
     queryKey: ['provider-credentials', currentOrgId],
@@ -352,6 +404,11 @@ export function SettingsProviderKeysPage() {
 
   return (
     <div>
+      {toastMessage && (
+        <div className="fixed top-6 right-6 z-50 rounded-lg bg-emerald-600 px-4 py-3 text-sm font-medium text-white shadow-lg">
+          {toastMessage}
+        </div>
+      )}
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
           Provider 키
@@ -409,11 +466,13 @@ export function SettingsProviderKeysPage() {
         isOpen={!!addingProvider}
         onClose={() => setAddingProvider(null)}
         provider={addingProvider}
+        onSuccessMessage={showToast}
       />
       <UpdateProviderModal
         isOpen={!!updatingCredential}
         onClose={() => setUpdatingCredential(null)}
         credential={updatingCredential}
+        onSuccessMessage={showToast}
       />
     </div>
   );

--- a/src/main/java/com/llm_ops/demo/keys/service/DefaultProviderCredentialVerifier.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/DefaultProviderCredentialVerifier.java
@@ -1,0 +1,100 @@
+package com.llm_ops.demo.keys.service;
+
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+import com.llm_ops.demo.gateway.service.GatewayChatOptionsCreateService;
+import com.llm_ops.demo.global.error.BusinessException;
+import com.llm_ops.demo.global.error.ErrorCode;
+import com.llm_ops.demo.keys.domain.ProviderType;
+import com.llm_ops.demo.prompt.service.PromptModelAllowlistService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("!test")
+@RequiredArgsConstructor
+public class DefaultProviderCredentialVerifier implements ProviderCredentialVerifier {
+
+    private static final String VALIDATION_PROMPT = "ping";
+    private static final String DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite";
+
+    private final PromptModelAllowlistService promptModelAllowlistService;
+    private final GatewayChatOptionsCreateService gatewayChatOptionsCreateService;
+
+    @Override
+    public void verify(ProviderType providerType, String apiKey) {
+        if (providerType == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 provider 입니다.");
+        }
+
+        String model = resolveValidationModel(providerType);
+
+        try {
+            switch (providerType) {
+                case OPENAI -> callOpenAi(apiKey, model);
+                case ANTHROPIC -> callAnthropic(apiKey, model);
+                case GEMINI -> callGemini(apiKey, model);
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "API 키 검증에 실패했습니다.");
+        }
+    }
+
+    private String resolveValidationModel(ProviderType providerType) {
+        Map<String, List<String>> allowlist = promptModelAllowlistService.getAllowlist();
+        List<String> models = allowlist.getOrDefault(providerType.name(), List.of());
+        String model = models.isEmpty() ? null : models.get(0);
+
+        if ((providerType == ProviderType.OPENAI || providerType == ProviderType.ANTHROPIC)
+                && (model == null || model.isBlank())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "검증 가능한 모델이 없습니다.");
+        }
+
+        return model;
+    }
+
+    private void callOpenAi(String apiKey, String model) {
+        OpenAiChatModel chatModel = new OpenAiChatModel(new OpenAiApi(apiKey));
+        OpenAiChatOptions options = OpenAiChatOptions.builder().build();
+        if (model != null && !model.isBlank()) {
+            options.setModel(model);
+        }
+        chatModel.call(new Prompt(new UserMessage(VALIDATION_PROMPT), options));
+    }
+
+    private void callAnthropic(String apiKey, String model) {
+        AnthropicChatModel chatModel = new AnthropicChatModel(new AnthropicApi(apiKey));
+        AnthropicChatOptions options = gatewayChatOptionsCreateService.anthropicOptions();
+        if (model != null && !model.isBlank()) {
+            options.setModel(model);
+        }
+        chatModel.call(new Prompt(new UserMessage(VALIDATION_PROMPT), options));
+    }
+
+    private void callGemini(String apiKey, String modelOverride) {
+        Client client = Client.builder().apiKey(apiKey).build();
+        String model = (modelOverride == null || modelOverride.isBlank())
+                ? DEFAULT_GEMINI_MODEL
+                : modelOverride;
+        GenerateContentResponse response = client.models.generateContent(
+                model,
+                VALIDATION_PROMPT,
+                null);
+        if (response == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "API 키 검증에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/llm_ops/demo/keys/service/NoopProviderCredentialVerifier.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/NoopProviderCredentialVerifier.java
@@ -1,0 +1,14 @@
+package com.llm_ops.demo.keys.service;
+
+import com.llm_ops.demo.keys.domain.ProviderType;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("test")
+public class NoopProviderCredentialVerifier implements ProviderCredentialVerifier {
+    @Override
+    public void verify(ProviderType providerType, String apiKey) {
+        // 테스트 환경에서는 외부 검증을 수행하지 않습니다.
+    }
+}

--- a/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerifier.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerifier.java
@@ -1,0 +1,7 @@
+package com.llm_ops.demo.keys.service;
+
+import com.llm_ops.demo.keys.domain.ProviderType;
+
+public interface ProviderCredentialVerifier {
+    void verify(ProviderType providerType, String apiKey);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,23 +54,23 @@ rag:
 prompt:
   model-allowlist:
     openai:
-      - gpt-4o
       - gpt-4o-mini
-      - gpt-4.1
+      - gpt-4o
       - gpt-4.1-mini
+      - gpt-4.1
       - gpt-4.1-nano
       - gpt-4
       - gpt-3.5-turbo
     anthropic:
-      - claude-3-5-sonnet
-      - claude-3-5-haiku
-      - claude-3-opus
-      - claude-3-sonnet
       - claude-3-haiku
       - claude-3-haiku-20240307
+      - claude-3-5-haiku
+      - claude-3-5-sonnet
+      - claude-3-opus
+      - claude-3-sonnet
     gemini:
-      - gemini-2.0-flash
       - gemini-2.5-flash-lite
+      - gemini-2.0-flash
 
 storage:
   s3:


### PR DESCRIPTION
…ss toast (#128)

* feat(provider-key): verify provider key on save/update; reorder model allowlist in application.yml

* feat(provider-key): frontend: success toast on provider key verification in SettingsProviderKeysPage.tsx

* feat(provider-key-verify): backend verifier and service for provider keys

* fix(frontend2): align prompt version types

* fix(frontend2): restore provider key modal state

---------

## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용
- 어떤 기능을 구현했는지 혹은 어떤 문제를 해결했는지 적어주세요.
- 주요 변경 사항을 요약해주세요.

## 📸 스크린샷 (선택)
- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부해주세요.

## 📚 레퍼런스 (선택)
- 참고한 링크나 문서가 있다면 적어주세요.

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?