### PR TITLE
feat(auth): 회원가입 이메일 중복체크/오류표시/성공 토스트 개선

### DIFF
--- a/frontend2/src/api/auth.api.ts
+++ b/frontend2/src/api/auth.api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import api from './axios';
 import type {
   ApiResponse,
+  EmailAvailabilityResponse,
   UserSignupRequest,
   UserSignupResponse,
   UserLoginRequest,
@@ -20,6 +21,10 @@ const authAxios = axios.create({
 });
 
 export const authApi = {
+  // 이메일 중복 체크 - GET /api/v1/auth/check-email
+  checkEmailAvailability: (email: string) =>
+    api.get<ApiResponse<EmailAvailabilityResponse>>('/auth/check-email', { params: { email } }),
+
   // 회원가입 - POST /api/v1/auth/signup
   signup: (data: UserSignupRequest) =>
     api.post<ApiResponse<UserSignupResponse>>('/auth/signup', data),

--- a/frontend2/src/pages/SignupPage.tsx
+++ b/frontend2/src/pages/SignupPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import type { UseFormRegisterReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
 import { authApi } from '@/api/auth.api';
 import { useAuthStore } from '@/features/auth/store';
 
@@ -20,6 +22,58 @@ const signupSchema = z
   });
 
 type SignupFormData = z.infer<typeof signupSchema>;
+type EmailCheckStatus = 'idle' | 'checking' | 'available' | 'duplicate' | 'error';
+type ToastTone = 'success' | 'error' | 'info';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function resolveApiError(error: unknown): {
+  message: string;
+  fieldErrors: Record<string, string>;
+} {
+  if (!axios.isAxiosError(error)) {
+    return {
+      message: '회원가입에 실패했습니다. 다시 시도해주세요.',
+      fieldErrors: {},
+    };
+  }
+
+  const payload = error.response?.data as
+    | {
+        message?: string;
+        fieldErrors?: unknown;
+      }
+    | undefined;
+
+  const fieldErrors: Record<string, string> = {};
+  const rawFieldErrors = payload?.fieldErrors;
+
+  if (Array.isArray(rawFieldErrors)) {
+    rawFieldErrors.forEach((item) => {
+      if (
+        item &&
+        typeof item === 'object' &&
+        'field' in item &&
+        'message' in item &&
+        typeof item.field === 'string' &&
+        typeof item.message === 'string'
+      ) {
+        fieldErrors[item.field] = item.message;
+      }
+    });
+  } else if (rawFieldErrors && typeof rawFieldErrors === 'object') {
+    Object.entries(rawFieldErrors as Record<string, unknown>).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        fieldErrors[key] = value;
+      }
+    });
+  }
+
+  return {
+    message: payload?.message ?? '회원가입에 실패했습니다. 다시 시도해주세요.',
+    fieldErrors,
+  };
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // AURORA BACKGROUND COMPONENT - Emerald variant for signup
@@ -172,14 +226,37 @@ interface FormInputProps {
   type: string;
   placeholder: string;
   error?: string;
+  helperText?: string;
+  helperTone?: 'default' | 'success' | 'error' | 'info';
   isFocused: boolean;
   onFocus: () => void;
   onBlur: () => void;
-  register: ReturnType<typeof useForm<SignupFormData>>['register'];
-  name: keyof SignupFormData;
+  onValueBlur?: (value: string) => void;
+  onValueChange?: (value: string) => void;
+  inputProps: UseFormRegisterReturn;
 }
 
-function FormInput({ label, type, placeholder, error, isFocused, onFocus, onBlur, register, name }: FormInputProps) {
+function FormInput({
+  label,
+  type,
+  placeholder,
+  error,
+  helperText,
+  helperTone = 'default',
+  isFocused,
+  onFocus,
+  onBlur,
+  onValueBlur,
+  onValueChange,
+  inputProps,
+}: FormInputProps) {
+  const helperTextClassName = {
+    default: 'text-white/50',
+    success: 'text-emerald-400',
+    error: 'text-red-400',
+    info: 'text-cyan-300',
+  }[helperTone];
+
   return (
     <div className="relative">
       <label
@@ -190,10 +267,18 @@ function FormInput({ label, type, placeholder, error, isFocused, onFocus, onBlur
       </label>
       <div className="relative">
         <input
-          {...register(name)}
+          {...inputProps}
           type={type}
           onFocus={onFocus}
-          onBlur={onBlur}
+          onBlur={(event) => {
+            inputProps.onBlur(event);
+            onBlur();
+            onValueBlur?.(event.target.value);
+          }}
+          onChange={(event) => {
+            inputProps.onChange(event);
+            onValueChange?.(event.target.value);
+          }}
           className="w-full px-0 py-3.5 bg-transparent border-0 border-b text-white placeholder-white/20 focus:outline-none transition-colors"
           style={{
             fontFamily: "'JetBrains Mono', monospace",
@@ -218,6 +303,14 @@ function FormInput({ label, type, placeholder, error, isFocused, onFocus, onBlur
           {error}
         </p>
       )}
+      {!error && helperText && (
+        <p
+          className={`mt-2 text-[12px] ${helperTextClassName}`}
+          style={{ fontFamily: "'JetBrains Mono', monospace" }}
+        >
+          {helperText}
+        </p>
+      )}
     </div>
   );
 }
@@ -230,6 +323,13 @@ export function SignupPage() {
   const navigate = useNavigate();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const [focusedField, setFocusedField] = useState<string | null>(null);
+  const [currentEmail, setCurrentEmail] = useState('');
+  const [emailCheckStatus, setEmailCheckStatus] = useState<EmailCheckStatus>('idle');
+  const [emailCheckMessage, setEmailCheckMessage] = useState<string | null>(null);
+  const [lastCheckedEmail, setLastCheckedEmail] = useState<string | null>(null);
+  const [signupErrorMessage, setSignupErrorMessage] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [toastTone, setToastTone] = useState<ToastTone>('info');
 
   // 이미 로그인된 사용자는 대시보드로 리다이렉트
   useEffect(() => {
@@ -241,24 +341,122 @@ export function SignupPage() {
   const {
     register,
     handleSubmit,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useForm<SignupFormData>({
     resolver: zodResolver(signupSchema),
   });
+  const normalizedWatchedEmail = currentEmail.trim();
+  const isEmailCheckPassed =
+    normalizedWatchedEmail.length > 0 &&
+    emailCheckStatus === 'available' &&
+    lastCheckedEmail === normalizedWatchedEmail;
+
+  const showToast = (message: string, tone: ToastTone) => {
+    setToastTone(tone);
+    setToastMessage(message);
+    window.setTimeout(() => {
+      setToastMessage(null);
+    }, 2500);
+  };
+
+  const handleEmailChange = (value: string) => {
+    setCurrentEmail(value);
+    const normalizedEmail = value.trim();
+    setSignupErrorMessage(null);
+
+    if (normalizedEmail !== lastCheckedEmail) {
+      setEmailCheckStatus('idle');
+      setEmailCheckMessage(null);
+      setLastCheckedEmail(null);
+      if (errors.email?.type === 'manual') {
+        clearErrors('email');
+      }
+    }
+  };
+
+  const handleEmailBlur = async (value: string) => {
+    const normalizedEmail = value.trim();
+
+    if (!normalizedEmail || !EMAIL_REGEX.test(normalizedEmail)) {
+      setEmailCheckStatus('idle');
+      setEmailCheckMessage(null);
+      setLastCheckedEmail(null);
+      return;
+    }
+
+    if (lastCheckedEmail === normalizedEmail && emailCheckStatus !== 'error') {
+      return;
+    }
+
+    setEmailCheckStatus('checking');
+    setEmailCheckMessage('이메일 중복 확인 중입니다...');
+
+    try {
+      const response = await authApi.checkEmailAvailability(normalizedEmail);
+      const availability = response.data.data;
+
+      setLastCheckedEmail(normalizedEmail);
+      setEmailCheckStatus(availability.available ? 'available' : 'duplicate');
+      setEmailCheckMessage(availability.message);
+
+      if (availability.available) {
+        clearErrors('email');
+      } else {
+        setError('email', {
+          type: 'manual',
+          message: availability.message,
+        });
+      }
+    } catch (error) {
+      const resolved = resolveApiError(error);
+      setEmailCheckStatus('error');
+      setEmailCheckMessage(resolved.message);
+      setLastCheckedEmail(null);
+    }
+  };
 
   const signupMutation = useMutation({
     mutationFn: (data: SignupFormData) =>
       authApi.signup({
-        email: data.email,
+        email: data.email.trim(),
         password: data.password,
         name: data.name,
       }),
     onSuccess: () => {
-      navigate('/login');
+      setSignupErrorMessage(null);
+      showToast('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.', 'success');
+      window.setTimeout(() => {
+        navigate('/login');
+      }, 900);
+    },
+    onError: (error) => {
+      const resolved = resolveApiError(error);
+      setSignupErrorMessage(resolved.message);
+
+      Object.entries(resolved.fieldErrors).forEach(([field, message]) => {
+        if (field === 'email' || field === 'password' || field === 'name' || field === 'confirmPassword') {
+          setError(field, { type: 'manual', message });
+        }
+      });
     },
   });
 
   const onSubmit = (data: SignupFormData) => {
+    setSignupErrorMessage(null);
+
+    if (!isEmailCheckPassed) {
+      const message =
+        emailCheckStatus === 'checking'
+          ? '이메일 중복 확인이 완료될 때까지 기다려주세요.'
+          : '이메일 중복 확인을 완료해주세요.';
+      setEmailCheckStatus('error');
+      setEmailCheckMessage(message);
+      setError('email', { type: 'manual', message });
+      return;
+    }
+
     signupMutation.mutate(data);
   };
 
@@ -268,6 +466,21 @@ export function SignupPage() {
       <style>{`
         @import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@300;400;500&family=JetBrains+Mono:wght@300;400;500&display=swap');
       `}</style>
+
+      {toastMessage && (
+        <div
+          className={`fixed top-6 right-6 z-50 px-5 py-3 border backdrop-blur-sm ${
+            toastTone === 'success'
+              ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+              : toastTone === 'error'
+                ? 'border-red-400/40 bg-red-500/10 text-red-200'
+                : 'border-cyan-400/40 bg-cyan-500/10 text-cyan-200'
+          }`}
+          style={{ fontFamily: "'JetBrains Mono', monospace" }}
+        >
+          <p className="text-[12px]">{toastMessage}</p>
+        </div>
+      )}
 
       {/* ════════════════════════════════════════════════════════════════════════ */}
       {/* LEFT SIDE - Aurora visual (reversed from login) */}
@@ -421,8 +634,7 @@ export function SignupPage() {
                 isFocused={focusedField === 'name'}
                 onFocus={() => setFocusedField('name')}
                 onBlur={() => setFocusedField(null)}
-                register={register}
-                name="name"
+                inputProps={register('name')}
               />
 
               <FormInput
@@ -430,11 +642,28 @@ export function SignupPage() {
                 type="email"
                 placeholder="email@company.com"
                 error={errors.email?.message}
+                helperText={
+                  errors.email?.message
+                    ? undefined
+                    : emailCheckMessage ?? '이메일 입력 후 포커스를 이동하면 중복 확인이 진행됩니다.'
+                }
+                helperTone={
+                  emailCheckStatus === 'available'
+                    ? 'success'
+                    : emailCheckStatus === 'duplicate' || emailCheckStatus === 'error'
+                      ? 'error'
+                      : emailCheckStatus === 'checking'
+                        ? 'info'
+                        : 'default'
+                }
                 isFocused={focusedField === 'email'}
                 onFocus={() => setFocusedField('email')}
                 onBlur={() => setFocusedField(null)}
-                register={register}
-                name="email"
+                onValueBlur={(value) => {
+                  void handleEmailBlur(value);
+                }}
+                onValueChange={handleEmailChange}
+                inputProps={register('email')}
               />
 
               <FormInput
@@ -445,8 +674,7 @@ export function SignupPage() {
                 isFocused={focusedField === 'password'}
                 onFocus={() => setFocusedField('password')}
                 onBlur={() => setFocusedField(null)}
-                register={register}
-                name="password"
+                inputProps={register('password')}
               />
 
               <FormInput
@@ -457,15 +685,14 @@ export function SignupPage() {
                 isFocused={focusedField === 'confirmPassword'}
                 onFocus={() => setFocusedField('confirmPassword')}
                 onBlur={() => setFocusedField(null)}
-                register={register}
-                name="confirmPassword"
+                inputProps={register('confirmPassword')}
               />
 
               {/* Submit button */}
               <div className="pt-4">
                 <button
                   type="submit"
-                  disabled={signupMutation.isPending}
+                  disabled={signupMutation.isPending || !isEmailCheckPassed}
                   className="group relative w-full py-5 overflow-hidden transition-all duration-300 disabled:opacity-50"
                   style={{
                     background: 'linear-gradient(135deg, oklch(0.65 0.18 160), oklch(0.55 0.15 180))',
@@ -498,13 +725,13 @@ export function SignupPage() {
               </div>
 
               {/* Error message */}
-              {signupMutation.isError && (
+              {signupErrorMessage && (
                 <div
                   className="p-4 border border-red-500/20 bg-red-500/5"
                   style={{ fontFamily: "'JetBrains Mono', monospace" }}
                 >
                   <p className="text-[12px] text-red-400">
-                    회원가입에 실패했습니다. 다시 시도해주세요.
+                    {signupErrorMessage}
                   </p>
                 </div>
               )}

--- a/frontend2/src/types/api.types.ts
+++ b/frontend2/src/types/api.types.ts
@@ -35,6 +35,11 @@ export interface UserSignupResponse {
   name: string;
 }
 
+export interface EmailAvailabilityResponse {
+  available: boolean;
+  message: string;
+}
+
 export interface UserLoginRequest {
   email: string;
   password: string;

--- a/src/main/java/com/llm_ops/demo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/llm_ops/demo/auth/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로
-                        .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/refresh")
+                        .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/refresh",
+                                "/api/v1/auth/check-email")
                         .permitAll()
                         // 게이트웨이 외부 호출(조직 API 키로 인증)
                         .requestMatchers("/v1/chat/**").permitAll()

--- a/src/main/java/com/llm_ops/demo/auth/controller/AuthController.java
+++ b/src/main/java/com/llm_ops/demo/auth/controller/AuthController.java
@@ -4,25 +4,44 @@ import com.llm_ops.demo.auth.service.AuthService;
 import com.llm_ops.demo.auth.dto.request.LoginRequest;
 import com.llm_ops.demo.auth.dto.request.SignUpRequest;
 import com.llm_ops.demo.auth.dto.request.TokenRefreshRequest;
+import com.llm_ops.demo.auth.dto.response.EmailAvailabilityResponse;
 import com.llm_ops.demo.auth.dto.response.LoginResponse;
 import com.llm_ops.demo.auth.dto.response.SignUpResponse;
 import com.llm_ops.demo.auth.dto.response.TokenRefreshResponse;
 import com.llm_ops.demo.auth.dto.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@Validated
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponse<EmailAvailabilityResponse>> checkEmailAvailability(
+            @RequestParam
+            @NotBlank
+            @Size(max = 50)
+            @Email
+            String email) {
+        EmailAvailabilityResponse response = authService.checkEmailAvailability(email);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignUpResponse>> signUp(@Valid @RequestBody SignUpRequest request) {

--- a/src/main/java/com/llm_ops/demo/auth/dto/response/EmailAvailabilityResponse.java
+++ b/src/main/java/com/llm_ops/demo/auth/dto/response/EmailAvailabilityResponse.java
@@ -1,0 +1,7 @@
+package com.llm_ops.demo.auth.dto.response;
+
+public record EmailAvailabilityResponse(
+        boolean available,
+        String message
+) {
+}

--- a/src/main/java/com/llm_ops/demo/auth/service/AuthService.java
+++ b/src/main/java/com/llm_ops/demo/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.llm_ops.demo.auth.domain.User;
 import com.llm_ops.demo.auth.dto.request.LoginRequest;
 import com.llm_ops.demo.auth.dto.request.SignUpRequest;
 import com.llm_ops.demo.auth.dto.request.TokenRefreshRequest;
+import com.llm_ops.demo.auth.dto.response.EmailAvailabilityResponse;
 import com.llm_ops.demo.auth.dto.response.LoginResponse;
 import com.llm_ops.demo.auth.dto.response.SignUpResponse;
 import com.llm_ops.demo.auth.dto.response.TokenRefreshResponse;
@@ -49,6 +50,13 @@ public class AuthService {
                 savedUser.getEmail(),
                 savedUser.getName(),
                 "회원가입이 완료되었습니다.");
+    }
+
+    @Transactional(readOnly = true)
+    public EmailAvailabilityResponse checkEmailAvailability(String email) {
+        boolean available = !userRepository.existsByEmail(email);
+        String message = available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다.";
+        return new EmailAvailabilityResponse(available, message);
     }
 
     @Transactional

--- a/src/test/java/com/llm_ops/demo/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/auth/service/AuthServiceTest.java
@@ -106,6 +106,41 @@ class AuthServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("이메일 중복 확인 테스트")
+    class CheckEmailAvailabilityTest {
+
+        @Test
+        @DisplayName("미등록 이메일이면 사용 가능 응답을 반환한다")
+        void 미등록_이메일이면_사용_가능_응답을_반환한다() {
+            // given
+            String email = "available@example.com";
+            given(userRepository.existsByEmail(email)).willReturn(false);
+
+            // when
+            var response = authService.checkEmailAvailability(email);
+
+            // then
+            assertThat(response.available()).isTrue();
+            assertThat(response.message()).isEqualTo("사용 가능한 이메일입니다.");
+        }
+
+        @Test
+        @DisplayName("등록된 이메일이면 사용 불가 응답을 반환한다")
+        void 등록된_이메일이면_사용_불가_응답을_반환한다() {
+            // given
+            String email = "duplicate@example.com";
+            given(userRepository.existsByEmail(email)).willReturn(true);
+
+            // when
+            var response = authService.checkEmailAvailability(email);
+
+            // then
+            assertThat(response.available()).isFalse();
+            assertThat(response.message()).isEqualTo("이미 사용 중인 이메일입니다.");
+        }
+    }
+
     // ==================== 로그인 테스트 ====================
     @Nested
     @DisplayName("로그인 테스트")


### PR DESCRIPTION
## 📌 관련 이슈
- 없음

## ✨ 작업 내용
- 회원가입 시 이메일 중복체크 API를 추가했습니다. (`GET /api/v1/auth/check-email`)
- 프론트 회원가입 화면에서 이메일 blur 시 중복체크를 수행하고, 상태 메시지를 표시하도록 변경했습니다.
- 중복체크가 완료되어 `available=true` 인 경우에만 회원가입 제출이 가능하도록 제어했습니다.
- 회원가입 실패 시 백엔드 오류 메시지를 그대로 노출하도록 개선했습니다.
- 회원가입 성공 시 토스트 메시지를 보여준 뒤 로그인 화면으로 이동하도록 개선했습니다.
- 관련 Auth 서비스/컨트롤러 테스트를 추가했습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- 없음

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?

리뷰 포인트:
- 이메일 중복체크 정책: 중복체크 성공(available=true) 전에는 회원가입 버튼이 비활성화됩니다.
- 백엔드 최종 중복검증은 기존처럼 유지되어 동시성 상황에서도 중복 가입이 차단됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 가용성 확인 API 엔드포인트 추가
  * 회원가입 페이지에서 실시간 이메일 중복 확인 기능 추가
  * 이메일 입력 시 가용성 상태를 인라인으로 표시
  * 회원가입 성공 시 토스트 알림 표시

* **테스트**
  * 이메일 가용성 확인 기능에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->