### PR TITLE
[Fix] Provider 키 검증 실패 시 UX 개선

### DIFF
--- a/src/main/java/com/llm_ops/demo/keys/service/DefaultProviderCredentialVerifier.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/DefaultProviderCredentialVerifier.java
@@ -150,7 +150,11 @@ public class DefaultProviderCredentialVerifier implements ProviderCredentialVeri
                     throw e;
                 }
             } catch (NonTransientAiException e) {
-                throw e;
+                BusinessException mapped = mapAiAuthException(e);
+                if (mapped != null && isAuthError(mapped)) {
+                    throw mapped;
+                }
+                // 모델 미발견(404) 등은 다음 모델로 fallback
             } catch (Exception ignored) {
                 // try next model
             }
@@ -186,7 +190,11 @@ public class DefaultProviderCredentialVerifier implements ProviderCredentialVeri
                     throw e;
                 }
             } catch (NonTransientAiException e) {
-                throw e;
+                BusinessException mapped = mapAiAuthException(e);
+                if (mapped != null && isAuthError(mapped)) {
+                    throw mapped;
+                }
+                // 모델 미발견(404) 등은 다음 모델로 fallback
             } catch (Exception ignored) {
                 // try next model
             }

--- a/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerificationService.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerificationService.java
@@ -43,8 +43,6 @@ public class ProviderCredentialVerificationService {
     private boolean isAuthFailure(BusinessException exception) {
         ErrorCode code = exception.getErrorCode();
         return code == ErrorCode.UNAUTHENTICATED
-                || code == ErrorCode.FORBIDDEN
-                || code == ErrorCode.INVALID_INPUT_VALUE
-                || code == ErrorCode.NOT_FOUND;
+                || code == ErrorCode.FORBIDDEN;
     }
 }

--- a/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerificationTimeoutService.java
+++ b/src/main/java/com/llm_ops/demo/keys/service/ProviderCredentialVerificationTimeoutService.java
@@ -29,7 +29,8 @@ public class ProviderCredentialVerificationTimeoutService {
             return;
         }
         for (ProviderCredential credential : stale) {
-            providerCredentialRepository.delete(credential);
+            credential.markInvalid();
         }
+        providerCredentialRepository.saveAll(stale);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용
  - NonTransientAiException(401/404)이 catch (Exception ignored)에 삼켜져 VERIFYING 상태가 유지되던 버그 수정 (OpenAI, Anthropic)                                                                                                           
  - 인증 실패 시 credential 삭제 대신 INVALID 상태로 변경하여 사용자에게 실패 원인 명시                                                                                                                                           
  - INVALID/VERIFYING 상태에서도 '키 업데이트' 버튼 노출되도록 프론트 수정
  - INVALID 상태 시 에러 메시지 표시 추가

## 📸 스크린샷 (선택)
<img width="1073" height="614" alt="image" src="https://github.com/user-attachments/assets/1df0bc4e-5710-42a6-a801-8b5d04c5699a" />


## 📚 레퍼런스 (선택)
- 참고한 링크나 문서가 있다면 적어주세요.

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 제공자 자격증명 검증 중 오류 처리 개선
  * 인증 실패 시 자격증명 관리 동작 개선

* **리팩토링**
  * 설정 페이지 코드 구조 및 형식 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->