### PR TITLE
feat: 평가 모드별 성능 지표 집계/시각화 추가 (#180)

### DIFF
--- a/frontend2/src/pages/prompt/components/PromptEvaluateTab.tsx
+++ b/frontend2/src/pages/prompt/components/PromptEvaluateTab.tsx
@@ -2734,15 +2734,16 @@ export function PromptEvaluateTab({ workspaceId, promptId }: { workspaceId: numb
                                     </div>
                                     <p className="mt-1 text-[11px] text-gray-500">진행률 {runProgressPercent}%</p>
                                 </div>
-	                                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-	                                    <KpiCard label="통과율" value={`${Number(selectedRun.summary?.passRate ?? 0).toFixed(2)}%`} tone="good" />
-	                                    <KpiCard label="평균 점수" value={formatOptionalNumber(toNullableNumber(selectedRun.summary?.avgOverallScore))} />
-	                                    <KpiCard label="통과" value={String(selectedRun.passedCases)} tone="good" />
-	                                    <KpiCard label="오류" value={String(selectedRun.errorCases)} tone={selectedRun.errorCases > 0 ? 'danger' : undefined} />
-	                                </div>
-                                <RunTrendCard runs={runs || []} />
-                            </>
-                        ) : null}
+		                                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+		                                    <KpiCard label="통과율" value={`${Number(selectedRun.summary?.passRate ?? 0).toFixed(2)}%`} tone="good" />
+		                                    <KpiCard label="평균 점수" value={formatOptionalNumber(toNullableNumber(selectedRun.summary?.avgOverallScore))} />
+		                                    <KpiCard label="통과" value={String(selectedRun.passedCases)} tone="good" />
+		                                    <KpiCard label="오류" value={String(selectedRun.errorCases)} tone={selectedRun.errorCases > 0 ? 'danger' : undefined} />
+		                                </div>
+                                <PerformanceModePanel run={selectedRun} />
+	                                <RunTrendCard runs={runs || []} />
+	                            </>
+	                        ) : null}
 
 	                        {resultSectionTab === 'CASES' ? (
 	                            <RunCaseList
@@ -2771,72 +2772,90 @@ export function PromptEvaluateTab({ workspaceId, promptId }: { workspaceId: numb
                     <div className="overflow-x-auto">
                         <table className="min-w-full text-sm">
 	                            <thead>
-	                                <tr className="text-left text-gray-400 border-b border-white/10">
-	                                    <th className="py-2 pr-3">Run 번호</th>
-	                                    <th className="py-2 pr-3">상태</th>
-	                                    <th className="py-2 pr-3">진행률</th>
-	                                    <th className="py-2 pr-3">통과율</th>
-	                                    <th className="py-2 pr-3">통과/실패/오류</th>
-	                                    <th className="py-2 pr-3">판정</th>
-	                                    <th className="py-2 pr-3">모드</th>
-	                                    <th className="py-2 pr-3">생성시각</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {(runs || []).map((run) => (
-                                    <tr
-                                        key={run.id}
-                                        className={`border-b border-white/5 cursor-pointer ${selectedRunId === run.id ? 'bg-white/10' : 'hover:bg-white/5'}`}
-                                        onClick={() => setSelectedRunId(run.id)}
-                                    >
-                                        <td className="py-2 pr-3 text-white">#{run.id}</td>
-                                        <td className="py-2 pr-3 text-gray-200">
-                                            <span className={`px-2 py-0.5 rounded-full text-[11px] ${runStatusBadgeClass(run.status)}`}>
-                                                {renderRunStatus(run.status)}
-                                            </span>
-                                        </td>
-                                        <td className="py-2 pr-3 text-gray-300">{run.processedCases}/{run.totalCases}</td>
-                                        <td className="py-2 pr-3 text-gray-300">{Number(run.summary?.passRate ?? 0).toFixed(1)}%</td>
-                                        <td className="py-2 pr-3 text-gray-300">{run.passedCases}/{run.failedCases}/{run.errorCases}</td>
-                                        <td className="py-2 pr-3 text-gray-300">{renderReleaseDecisionBadge(run.summary?.releaseDecision)}</td>
-                                        <td className="py-2 pr-3 text-gray-300">{renderModeLabel(run.mode)}</td>
-                                        <td className="py-2 pr-3 text-gray-400">{new Date(run.createdAt).toLocaleString('ko-KR')}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                ) : resultSectionTab === 'PERFORMANCE' ? (
-                    <details className="rounded-md border border-white/10 bg-black/20 p-2">
-                        <summary className="cursor-pointer text-[11px] text-gray-300">실행 히스토리 보기 (기술 상세)</summary>
-                        <div className="overflow-x-auto mt-2">
-                            <table className="min-w-full text-sm">
-	                                <thead>
-	                                    <tr className="text-left text-gray-400 border-b border-white/10">
-	                                        <th className="py-2 pr-3">Run 번호</th>
-	                                        <th className="py-2 pr-3">상태</th>
-	                                        <th className="py-2 pr-3">판정</th>
-	                                        <th className="py-2 pr-3">통과율</th>
-	                                        <th className="py-2 pr-3">생성시각</th>
-	                                    </tr>
-	                                </thead>
-                                <tbody>
-                                    {(runs || []).map((run) => (
+		                                <tr className="text-left text-gray-400 border-b border-white/10">
+		                                    <th className="py-2 pr-3">Run 번호</th>
+		                                    <th className="py-2 pr-3">상태</th>
+		                                    <th className="py-2 pr-3">진행률</th>
+		                                    <th className="py-2 pr-3">통과율</th>
+		                                    <th className="py-2 pr-3">통과/실패/오류</th>
+                                    <th className="py-2 pr-3">평균 토큰/케이스</th>
+                                    <th className="py-2 pr-3">평균 비용/케이스(USD)</th>
+                                    <th className="py-2 pr-3">p95 지연(ms)</th>
+		                                    <th className="py-2 pr-3">판정</th>
+		                                    <th className="py-2 pr-3">모드</th>
+		                                    <th className="py-2 pr-3">생성시각</th>
+		                                </tr>
+		                            </thead>
+		                            <tbody>
+                                {(runs || []).map((run) => {
+                                    const runPerformance = extractRunPerformance(run.summary);
+                                    const candidatePerformance = runPerformance?.candidate ?? null;
+                                    return (
                                         <tr
                                             key={run.id}
                                             className={`border-b border-white/5 cursor-pointer ${selectedRunId === run.id ? 'bg-white/10' : 'hover:bg-white/5'}`}
                                             onClick={() => setSelectedRunId(run.id)}
                                         >
                                             <td className="py-2 pr-3 text-white">#{run.id}</td>
-                                            <td className="py-2 pr-3 text-gray-200">{renderRunStatus(run.status)}</td>
-                                            <td className="py-2 pr-3 text-gray-300">{renderReleaseDecisionBadge(run.summary?.releaseDecision)}</td>
+                                            <td className="py-2 pr-3 text-gray-200">
+                                                <span className={`px-2 py-0.5 rounded-full text-[11px] ${runStatusBadgeClass(run.status)}`}>
+                                                    {renderRunStatus(run.status)}
+                                                </span>
+                                            </td>
+                                            <td className="py-2 pr-3 text-gray-300">{run.processedCases}/{run.totalCases}</td>
                                             <td className="py-2 pr-3 text-gray-300">{Number(run.summary?.passRate ?? 0).toFixed(1)}%</td>
+                                            <td className="py-2 pr-3 text-gray-300">{run.passedCases}/{run.failedCases}/{run.errorCases}</td>
+                                            <td className="py-2 pr-3 text-gray-300">{formatMetricValue(candidatePerformance?.avgTokensPerCase, 2)}</td>
+                                            <td className="py-2 pr-3 text-gray-300">{formatMetricValue(candidatePerformance?.avgCostUsdPerCase, 6)}</td>
+                                            <td className="py-2 pr-3 text-gray-300">{formatMetricValue(candidatePerformance?.p95LatencyMs, 2)}</td>
+                                            <td className="py-2 pr-3 text-gray-300">{renderReleaseDecisionBadge(run.summary?.releaseDecision)}</td>
+                                            <td className="py-2 pr-3 text-gray-300">{renderModeLabel(run.mode)}</td>
                                             <td className="py-2 pr-3 text-gray-400">{new Date(run.createdAt).toLocaleString('ko-KR')}</td>
                                         </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
+                                    );
+                                })}
+		                            </tbody>
+		                        </table>
+		                    </div>
+                ) : resultSectionTab === 'PERFORMANCE' ? (
+                    <details className="rounded-md border border-white/10 bg-black/20 p-2">
+                        <summary className="cursor-pointer text-[11px] text-gray-300">실행 히스토리 보기 (기술 상세)</summary>
+                        <div className="overflow-x-auto mt-2">
+                            <table className="min-w-full text-sm">
+	                                <thead>
+		                                    <tr className="text-left text-gray-400 border-b border-white/10">
+		                                        <th className="py-2 pr-3">Run 번호</th>
+		                                        <th className="py-2 pr-3">상태</th>
+		                                        <th className="py-2 pr-3">판정</th>
+		                                        <th className="py-2 pr-3">통과율</th>
+                                        <th className="py-2 pr-3">평균 비용/케이스(USD)</th>
+                                        <th className="py-2 pr-3">p95 지연(ms)</th>
+		                                        <th className="py-2 pr-3">생성시각</th>
+		                                    </tr>
+		                                </thead>
+	                                <tbody>
+                                    {(runs || []).map((run) => {
+                                        const runPerformance = extractRunPerformance(run.summary);
+                                        const candidatePerformance = runPerformance?.candidate ?? null;
+                                        return (
+                                            <tr
+                                                key={run.id}
+                                                className={`border-b border-white/5 cursor-pointer ${selectedRunId === run.id ? 'bg-white/10' : 'hover:bg-white/5'}`}
+                                                onClick={() => setSelectedRunId(run.id)}
+                                            >
+                                                <td className="py-2 pr-3 text-white">#{run.id}</td>
+                                                <td className="py-2 pr-3 text-gray-200">{renderRunStatus(run.status)}</td>
+                                                <td className="py-2 pr-3 text-gray-300">{renderReleaseDecisionBadge(run.summary?.releaseDecision)}</td>
+                                                <td className="py-2 pr-3 text-gray-300">{Number(run.summary?.passRate ?? 0).toFixed(1)}%</td>
+                                                <td className="py-2 pr-3 text-gray-300">{formatMetricValue(candidatePerformance?.avgCostUsdPerCase, 6)}</td>
+                                                <td className="py-2 pr-3 text-gray-300">{formatMetricValue(candidatePerformance?.p95LatencyMs, 2)}</td>
+                                                <td className="py-2 pr-3 text-gray-400">{new Date(run.createdAt).toLocaleString('ko-KR')}</td>
+                                            </tr>
+                                        );
+                                    })}
+	                                </tbody>
+	                            </table>
+	                        </div>
                     </details>
                 ) : null}
 
@@ -3792,6 +3811,99 @@ function KpiCard({
     );
 }
 
+function PerformanceModePanel({ run }: { run: EvalRunResponse }) {
+    const performance = extractRunPerformance(run.summary);
+    if (!performance) {
+        return (
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+                <p className="text-xs text-gray-300">성능 지표 데이터가 아직 없습니다.</p>
+            </div>
+        );
+    }
+
+    const candidate = performance.candidate;
+    const baseline = performance.baseline;
+    const delta = performance.delta;
+    const isCompare = run.mode === 'COMPARE_ACTIVE';
+
+    if (!isCompare) {
+        return (
+            <div className="space-y-2">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                    <KpiCard label="평균 토큰/케이스" value={formatMetricValue(candidate.avgTokensPerCase, 2)} />
+                    <KpiCard label="평균 비용/케이스(USD)" value={formatMetricValue(candidate.avgCostUsdPerCase, 6)} />
+                    <KpiCard label="평균 지연(ms)" value={formatMetricValue(candidate.avgLatencyMs, 2)} />
+                    <KpiCard label="p95 지연(ms)" value={formatMetricValue(candidate.p95LatencyMs, 2)} />
+                </div>
+                <p className="text-[11px] text-gray-500">
+                    샘플 수: case {candidate.sampleSize} / tokens {candidate.tokenSampleSize} / cost {candidate.costSampleSize} / latency {candidate.latencySampleSize}
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <PerformanceCompareMetricCard
+                    label="평균 토큰/케이스"
+                    candidate={candidate.avgTokensPerCase}
+                    baseline={baseline?.avgTokensPerCase}
+                    delta={delta?.avgTokensPerCase ?? null}
+                />
+                <PerformanceCompareMetricCard
+                    label="평균 비용/케이스(USD)"
+                    candidate={candidate.avgCostUsdPerCase}
+                    baseline={baseline?.avgCostUsdPerCase}
+                    delta={delta?.avgCostUsdPerCase ?? null}
+                    valueScale={6}
+                />
+                <PerformanceCompareMetricCard
+                    label="평균 지연(ms)"
+                    candidate={candidate.avgLatencyMs}
+                    baseline={baseline?.avgLatencyMs}
+                    delta={delta?.avgLatencyMs ?? null}
+                />
+                <PerformanceCompareMetricCard
+                    label="p95 지연(ms)"
+                    candidate={candidate.p95LatencyMs}
+                    baseline={baseline?.p95LatencyMs}
+                    delta={delta?.p95LatencyMs ?? null}
+                />
+            </div>
+            <p className="text-[11px] text-gray-500">
+                샘플 수(이번/운영): case {candidate.sampleSize}/{baseline?.sampleSize ?? 0}, tokens {candidate.tokenSampleSize}/{baseline?.tokenSampleSize ?? 0}, cost {candidate.costSampleSize}/{baseline?.costSampleSize ?? 0}, latency {candidate.latencySampleSize}/{baseline?.latencySampleSize ?? 0}
+            </p>
+        </div>
+    );
+}
+
+function PerformanceCompareMetricCard({
+    label,
+    candidate,
+    baseline,
+    delta,
+    valueScale = 2,
+}: {
+    label: string;
+    candidate: number | null;
+    baseline: number | null | undefined;
+    delta: PerformanceMetricDeltaView | null;
+    valueScale?: number;
+}) {
+    const tone = inverseDeltaTone(delta?.value ?? null);
+    return (
+        <div className="rounded-lg border border-white/10 bg-black/25 px-3 py-2 space-y-1">
+            <p className="text-[11px] text-gray-400">{label}</p>
+            <p className="text-[12px] text-gray-200">이번: {formatMetricValue(candidate, valueScale)}</p>
+            <p className="text-[12px] text-gray-300">운영: {formatMetricValue(baseline, valueScale)}</p>
+            <p className={`text-[11px] ${tone === 'danger' ? 'text-rose-200' : tone === 'good' ? 'text-emerald-200' : 'text-amber-200'}`}>
+                {formatDeltaText(delta, valueScale)}
+            </p>
+        </div>
+    );
+}
+
 function RuleSummaryCard({ title, checks }: { title: string; checks: Record<string, any> | null }) {
     const pass = toNullableBoolean(checks?.pass);
     const failedChecks = toStringArray(checks?.failedChecks);
@@ -3919,6 +4031,33 @@ type CompareSummaryView = {
     winner?: string | null;
 };
 
+type PerformanceMetricDeltaView = {
+    value: number | null;
+    pct: number | null;
+};
+
+type PerformanceSnapshotView = {
+    avgTokensPerCase: number | null;
+    avgCostUsdPerCase: number | null;
+    avgLatencyMs: number | null;
+    p95LatencyMs: number | null;
+    sampleSize: number;
+    tokenSampleSize: number;
+    costSampleSize: number;
+    latencySampleSize: number;
+};
+
+type RunPerformanceView = {
+    candidate: PerformanceSnapshotView;
+    baseline: PerformanceSnapshotView | null;
+    delta: {
+        avgTokensPerCase: PerformanceMetricDeltaView;
+        avgCostUsdPerCase: PerformanceMetricDeltaView;
+        avgLatencyMs: PerformanceMetricDeltaView;
+        p95LatencyMs: PerformanceMetricDeltaView;
+    } | null;
+};
+
 type RunDecisionView = {
     decision: string;
     decisionLabel: string;
@@ -4010,6 +4149,65 @@ function extractCompareSummary(judgeOutput: Record<string, any> | null | undefin
         baselinePass: toNullableBoolean(compare.baselinePass),
         scoreDelta: toNullableNumber(compare.scoreDelta),
         winner: compare.winner != null ? String(compare.winner) : null,
+    };
+}
+
+function extractRunPerformance(summary: Record<string, any> | null | undefined): RunPerformanceView | null {
+    if (!isObject(summary) || !isObject(summary.performance)) {
+        return null;
+    }
+
+    const performance = summary.performance as Record<string, any>;
+    const candidate = extractPerformanceSnapshot(performance.candidate);
+    if (!candidate) {
+        return null;
+    }
+
+    const baseline = extractPerformanceSnapshot(performance.baseline);
+    const delta = extractPerformanceDelta(performance.delta);
+
+    return {
+        candidate,
+        baseline,
+        delta,
+    };
+}
+
+function extractPerformanceSnapshot(raw: unknown): PerformanceSnapshotView | null {
+    if (!isObject(raw)) {
+        return null;
+    }
+    return {
+        avgTokensPerCase: toNullableNumber(raw.avgTokensPerCase),
+        avgCostUsdPerCase: toNullableNumber(raw.avgCostUsdPerCase),
+        avgLatencyMs: toNullableNumber(raw.avgLatencyMs),
+        p95LatencyMs: toNullableNumber(raw.p95LatencyMs),
+        sampleSize: toSafeInteger(raw.sampleSize),
+        tokenSampleSize: toSafeInteger(raw.tokenSampleSize),
+        costSampleSize: toSafeInteger(raw.costSampleSize),
+        latencySampleSize: toSafeInteger(raw.latencySampleSize),
+    };
+}
+
+function extractPerformanceDelta(raw: unknown): RunPerformanceView['delta'] {
+    if (!isObject(raw)) {
+        return null;
+    }
+    return {
+        avgTokensPerCase: extractPerformanceMetricDelta(raw.avgTokensPerCase),
+        avgCostUsdPerCase: extractPerformanceMetricDelta(raw.avgCostUsdPerCase),
+        avgLatencyMs: extractPerformanceMetricDelta(raw.avgLatencyMs),
+        p95LatencyMs: extractPerformanceMetricDelta(raw.p95LatencyMs),
+    };
+}
+
+function extractPerformanceMetricDelta(raw: unknown): PerformanceMetricDeltaView {
+    if (!isObject(raw)) {
+        return { value: null, pct: null };
+    }
+    return {
+        value: toNullableNumber(raw.value),
+        pct: toNullableNumber(raw.pct),
     };
 }
 
@@ -4121,6 +4319,38 @@ function compareDeltaBadgeClass(tone: 'good' | 'warn' | 'danger' | undefined): s
     return badgePillClass('neutral');
 }
 
+function formatMetricValue(value: number | null | undefined, scale = 2): string {
+    if (value == null || Number.isNaN(value)) {
+        return '-';
+    }
+    return Number(value).toFixed(scale);
+}
+
+function formatDeltaText(delta: PerformanceMetricDeltaView | null, scale = 2): string {
+    if (!delta || delta.value == null || Number.isNaN(delta.value)) {
+        return 'Δ -';
+    }
+    const valuePart = `${delta.value > 0 ? '+' : ''}${Number(delta.value).toFixed(scale)}`;
+    if (delta.pct == null || Number.isNaN(delta.pct)) {
+        return `Δ ${valuePart}`;
+    }
+    const pctPart = `${delta.pct > 0 ? '+' : ''}${Number(delta.pct).toFixed(2)}%`;
+    return `Δ ${valuePart} (${pctPart})`;
+}
+
+function inverseDeltaTone(value: number | null): 'good' | 'warn' | 'danger' | undefined {
+    if (value == null || Number.isNaN(value)) {
+        return undefined;
+    }
+    if (value > 0) {
+        return 'danger';
+    }
+    if (value < 0) {
+        return 'good';
+    }
+    return 'warn';
+}
+
 function formatOptionalNumber(value: number | null | undefined): string {
     if (value == null || Number.isNaN(value)) {
         return '-';
@@ -4166,6 +4396,14 @@ function toNullableNumber(value: any): number | null {
     }
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toSafeInteger(value: unknown): number {
+    const parsed = toNullableNumber(value);
+    if (parsed == null || parsed < 0) {
+        return 0;
+    }
+    return Math.round(parsed);
 }
 
 function toNullableBoolean(value: any): boolean | null {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalPerformanceSummaryCalculator.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalPerformanceSummaryCalculator.java
@@ -1,0 +1,163 @@
+package com.llm_ops.demo.eval.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EvalPerformanceSummaryCalculator {
+
+    public Map<String, Object> buildSummary(
+            List<Map<String, Object>> candidateMetas,
+            List<Map<String, Object>> baselineMetas,
+            boolean compareMode
+    ) {
+        PerformanceSnapshot candidate = PerformanceSnapshot.from(candidateMetas);
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("candidate", candidate.toMap());
+
+        if (!compareMode) {
+            return summary;
+        }
+
+        PerformanceSnapshot baseline = PerformanceSnapshot.from(baselineMetas);
+        summary.put("baseline", baseline.toMap());
+        summary.put("delta", buildDelta(candidate, baseline));
+        return summary;
+    }
+
+    private Map<String, Object> buildDelta(PerformanceSnapshot candidate, PerformanceSnapshot baseline) {
+        Map<String, Object> delta = new LinkedHashMap<>();
+        delta.put("avgTokensPerCase", metricDelta(candidate.avgTokensPerCase, baseline.avgTokensPerCase, 2));
+        delta.put("avgCostUsdPerCase", metricDelta(candidate.avgCostUsdPerCase, baseline.avgCostUsdPerCase, 6));
+        delta.put("avgLatencyMs", metricDelta(candidate.avgLatencyMs, baseline.avgLatencyMs, 2));
+        delta.put("p95LatencyMs", metricDelta(candidate.p95LatencyMs, baseline.p95LatencyMs, 2));
+        return delta;
+    }
+
+    private Map<String, Object> metricDelta(Double candidate, Double baseline, int valueScale) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (candidate == null || baseline == null) {
+            result.put("value", null);
+            result.put("pct", null);
+            return result;
+        }
+
+        double diff = candidate - baseline;
+        result.put("value", round(diff, valueScale));
+
+        if (Math.abs(baseline) < 0.0000001d) {
+            result.put("pct", null);
+        } else {
+            result.put("pct", round((diff / baseline) * 100.0, 2));
+        }
+        return result;
+    }
+
+    private static Double readDouble(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return Double.parseDouble(String.valueOf(value));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Double average(List<Double> values, int scale) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        double sum = values.stream().mapToDouble(Double::doubleValue).sum();
+        return round(sum / values.size(), scale);
+    }
+
+    private static Double percentile95(List<Double> values, int scale) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        List<Double> sorted = values.stream().sorted().toList();
+        int rank = (int) Math.ceil(sorted.size() * 0.95d) - 1;
+        int index = Math.max(0, Math.min(rank, sorted.size() - 1));
+        return round(sorted.get(index), scale);
+    }
+
+    private static double round(double value, int scale) {
+        return BigDecimal.valueOf(value).setScale(scale, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    private record PerformanceSnapshot(
+            Double avgTokensPerCase,
+            Double avgCostUsdPerCase,
+            Double avgLatencyMs,
+            Double p95LatencyMs,
+            int sampleSize,
+            int tokenSampleSize,
+            int costSampleSize,
+            int latencySampleSize
+    ) {
+        static PerformanceSnapshot from(List<Map<String, Object>> metas) {
+            List<Double> tokenValues = new ArrayList<>();
+            List<Double> costValues = new ArrayList<>();
+            List<Double> latencyValues = new ArrayList<>();
+            int sampleSize = 0;
+
+            if (metas != null) {
+                for (Map<String, Object> meta : metas) {
+                    if (meta == null || meta.isEmpty()) {
+                        continue;
+                    }
+
+                    Double tokens = readDouble(meta.get("totalTokens"));
+                    Double cost = readDouble(meta.get("estimatedCostUsd"));
+                    Double latency = readDouble(meta.get("latencyMs"));
+
+                    if (tokens != null) {
+                        tokenValues.add(tokens);
+                    }
+                    if (cost != null) {
+                        costValues.add(cost);
+                    }
+                    if (latency != null) {
+                        latencyValues.add(latency);
+                    }
+                    if (tokens != null || cost != null || latency != null) {
+                        sampleSize++;
+                    }
+                }
+            }
+
+            return new PerformanceSnapshot(
+                    average(tokenValues, 2),
+                    average(costValues, 6),
+                    average(latencyValues, 2),
+                    percentile95(latencyValues, 2),
+                    sampleSize,
+                    tokenValues.size(),
+                    costValues.size(),
+                    latencyValues.size()
+            );
+        }
+
+        Map<String, Object> toMap() {
+            Map<String, Object> map = new LinkedHashMap<>();
+            map.put("avgTokensPerCase", avgTokensPerCase);
+            map.put("avgCostUsdPerCase", avgCostUsdPerCase);
+            map.put("avgLatencyMs", avgLatencyMs);
+            map.put("p95LatencyMs", p95LatencyMs);
+            map.put("sampleSize", sampleSize);
+            map.put("tokenSampleSize", tokenSampleSize);
+            map.put("costSampleSize", costSampleSize);
+            map.put("latencySampleSize", latencySampleSize);
+            return map;
+        }
+    }
+}

--- a/src/test/java/com/llm_ops/demo/eval/service/EvalPerformanceSummaryCalculatorTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/service/EvalPerformanceSummaryCalculatorTest.java
@@ -1,0 +1,96 @@
+package com.llm_ops.demo.eval.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EvalPerformanceSummaryCalculatorTest {
+
+    private final EvalPerformanceSummaryCalculator calculator = new EvalPerformanceSummaryCalculator();
+
+    @Test
+    @DisplayName("단일 모드 성능 요약은 평균/퍼센타일 지표를 계산한다")
+    void 단일_모드_성능_요약은_평균_퍼센타일_지표를_계산한다() {
+        // given
+        List<Map<String, Object>> candidateMetas = List.of(
+                Map.of("totalTokens", 100, "estimatedCostUsd", 0.01, "latencyMs", 200),
+                Map.of("totalTokens", 200, "estimatedCostUsd", 0.03, "latencyMs", 300),
+                Map.of("totalTokens", 300, "estimatedCostUsd", 0.05, "latencyMs", 1000)
+        );
+
+        // when
+        Map<String, Object> summary = calculator.buildSummary(candidateMetas, List.of(), false);
+        Map<String, Object> candidate = toObjectMap(summary.get("candidate"));
+
+        // then
+        assertThat(candidate.get("avgTokensPerCase")).isEqualTo(200.0);
+        assertThat(candidate.get("avgCostUsdPerCase")).isEqualTo(0.03);
+        assertThat(candidate.get("avgLatencyMs")).isEqualTo(500.0);
+        assertThat(candidate.get("p95LatencyMs")).isEqualTo(1000.0);
+        assertThat(candidate.get("sampleSize")).isEqualTo(3);
+        assertThat(summary).doesNotContainKey("baseline");
+        assertThat(summary).doesNotContainKey("delta");
+    }
+
+    @Test
+    @DisplayName("비교 모드 성능 요약은 baseline 대비 delta와 deltaPct를 계산한다")
+    void 비교_모드_성능_요약은_baseline_대비_delta와_deltaPct를_계산한다() {
+        // given
+        List<Map<String, Object>> candidateMetas = List.of(
+                Map.of("totalTokens", 200, "estimatedCostUsd", 0.02, "latencyMs", 220),
+                Map.of("totalTokens", 100, "estimatedCostUsd", 0.01, "latencyMs", 440)
+        );
+        List<Map<String, Object>> baselineMetas = List.of(
+                Map.of("totalTokens", 100, "estimatedCostUsd", 0.01, "latencyMs", 110),
+                Map.of("totalTokens", 100, "estimatedCostUsd", 0.01, "latencyMs", 220)
+        );
+
+        // when
+        Map<String, Object> summary = calculator.buildSummary(candidateMetas, baselineMetas, true);
+        Map<String, Object> delta = toObjectMap(summary.get("delta"));
+
+        Map<String, Object> tokensDelta = toObjectMap(delta.get("avgTokensPerCase"));
+        Map<String, Object> costDelta = toObjectMap(delta.get("avgCostUsdPerCase"));
+        Map<String, Object> p95Delta = toObjectMap(delta.get("p95LatencyMs"));
+
+        // then
+        assertThat(tokensDelta.get("value")).isEqualTo(50.0);
+        assertThat(tokensDelta.get("pct")).isEqualTo(50.0);
+        assertThat(costDelta.get("value")).isEqualTo(0.005);
+        assertThat(costDelta.get("pct")).isEqualTo(50.0);
+        assertThat(p95Delta.get("value")).isEqualTo(220.0);
+        assertThat(p95Delta.get("pct")).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("baseline이 0이면 deltaPct는 null로 계산한다")
+    void baseline이_0이면_deltaPct는_null로_계산한다() {
+        // given
+        List<Map<String, Object>> candidateMetas = List.of(
+                Map.of("totalTokens", 10, "estimatedCostUsd", 0.001, "latencyMs", 100)
+        );
+        List<Map<String, Object>> baselineMetas = List.of(
+                Map.of("totalTokens", 0, "estimatedCostUsd", 0.0, "latencyMs", 0)
+        );
+
+        // when
+        Map<String, Object> summary = calculator.buildSummary(candidateMetas, baselineMetas, true);
+        Map<String, Object> delta = toObjectMap(summary.get("delta"));
+        Map<String, Object> tokensDelta = toObjectMap(delta.get("avgTokensPerCase"));
+        Map<String, Object> costDelta = toObjectMap(delta.get("avgCostUsdPerCase"));
+        Map<String, Object> latencyDelta = toObjectMap(delta.get("avgLatencyMs"));
+
+        // then
+        assertThat(tokensDelta.get("pct")).isNull();
+        assertThat(costDelta.get("pct")).isNull();
+        assertThat(latencyDelta.get("pct")).isNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> toObjectMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #180

## ✨ 작업 내용
- Prompt Eval 실행 완료 시 `summary.performance`를 계산/저장하도록 백엔드 집계 로직을 추가했습니다.
- 단일 모드(`CANDIDATE_ONLY`)에서는 후보 버전 기준 평균 토큰/케이스, 평균 비용/케이스, 평균/`p95` 지연, 샘플 수를 제공합니다.
- 비교 모드(`COMPARE_ACTIVE`)에서는 후보/운영(Baseline) 지표와 함께 Delta(value/pct)를 제공합니다.
- 프론트 평가 상세 화면에 모드별 성능 패널을 추가하고, 실행 이력 테이블에도 평균 토큰/비용/`p95` 컬럼을 노출했습니다.
- 성능 집계 계산기 단위 테스트를 추가했습니다.

## 🎯 변경 이유
- 기존 평가는 pass/fail 중심으로 품질 판정은 가능했지만, 운영 관점에서 중요한 성능/비용(토큰, 레이턴시, 비용) 비교가 어려웠습니다.
- 평가 모드(단일/비교)에 맞는 성능 가시성을 제공해 배포 의사결정 근거를 강화하기 위함입니다.

## ✅ 검증 명령
- `./gradlew test --tests "com.llm_ops.demo.eval.service.EvalPerformanceSummaryCalculatorTest" --tests "com.llm_ops.demo.eval.*"`
- `cd frontend2 && npm run build`
- 수동 검증: 평가 Run 실행 후 `summary.performance`에 `candidate/baseline/delta` 저장 확인 (Run #186)

## ⚠️ 리스크 및 롤백 포인트
- 리스크: 모델 응답 메타(`totalTokens`, `latencyMs`, `estimatedCostUsd`)가 비어 있으면 일부 지표가 `null`로 표시될 수 있습니다.
- 롤백 포인트: `summary.performance` 집계/노출 변경만 되돌리면 기존 평가 흐름(pass/fail/score)은 유지됩니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- 없음

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 평가 결과에 성능 메트릭 표시: 토큰 사용량, 비용, 지연시간(평균 및 p95) 등의 성능 지표를 상세하게 시각화하여 제공
* 성능 비교 분석 기능: 후보 버전과 기준 버전 간 성능 차이를 델타 값 및 백분율 변화로 나타내어 상세 비교 분석 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->