### PR TITLE
fix: prompt allowlist 모델 pricing 동기화 #184

### DIFF
--- a/src/main/java/com/llm_ops/demo/gateway/pricing/ModelPricing.java
+++ b/src/main/java/com/llm_ops/demo/gateway/pricing/ModelPricing.java
@@ -19,6 +19,9 @@ public class ModelPricing {
         // OpenAI
         PRICING_TABLE.put("gpt-4o", new PriceInfo("0.005", "0.015"));
         PRICING_TABLE.put("gpt-4o-mini", new PriceInfo("0.00015", "0.0006"));
+        PRICING_TABLE.put("gpt-4.1", new PriceInfo("0.002", "0.008"));
+        PRICING_TABLE.put("gpt-4.1-mini", new PriceInfo("0.0004", "0.0016"));
+        PRICING_TABLE.put("gpt-4.1-nano", new PriceInfo("0.0001", "0.0004"));
         PRICING_TABLE.put("gpt-4", new PriceInfo("0.03", "0.06"));
         PRICING_TABLE.put("gpt-3.5-turbo", new PriceInfo("0.0005", "0.0015"));
 

--- a/src/test/java/com/llm_ops/demo/gateway/pricing/ModelPricingTest.java
+++ b/src/test/java/com/llm_ops/demo/gateway/pricing/ModelPricingTest.java
@@ -3,6 +3,7 @@ package com.llm_ops.demo.gateway.pricing;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ModelPricingTest {
@@ -24,5 +25,36 @@ class ModelPricingTest {
         BigDecimal cost = ModelPricing.calculateCost("gemini-2.5-flash", 1000, 1000);
         assertThat(cost).isGreaterThan(BigDecimal.ZERO);
     }
-}
 
+    @Test
+    void isKnownModel_supportsPromptModelAllowlist() {
+        // prompt.model-allowlist (application.yml) 에 등록된 모델은 비용 인식이 가능해야 한다.
+        List<String> allowlistModels = List.of(
+                "gpt-4o-mini",
+                "gpt-4o",
+                "gpt-4.1-mini",
+                "gpt-4.1",
+                "gpt-4.1-nano",
+                "gpt-4",
+                "gpt-3.5-turbo",
+                "claude-3-haiku-20240307",
+                "claude-3-haiku",
+                "claude-3-5-haiku",
+                "claude-3-5-sonnet",
+                "claude-3-opus",
+                "claude-3-sonnet",
+                "gemini-2.5-flash",
+                "gemini-2.5-flash-lite",
+                "gemini-2.0-flash"
+        );
+
+        assertThat(allowlistModels)
+                .allMatch(ModelPricing::isKnownModel);
+    }
+
+    @Test
+    void calculateCost_gpt41MiniVersionedModel_isNotZero() {
+        BigDecimal cost = ModelPricing.calculateCost("gpt-4.1-mini-2025-04-14", 1000, 1000);
+        assertThat(cost).isGreaterThan(BigDecimal.ZERO);
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `ModelPricing`에 OpenAI 3개 모델 단가 추가
  - `gpt-4.1`
  - `gpt-4.1-mini`
  - `gpt-4.1-nano`
- 가격 인식 회귀 방지 테스트 추가
  - allowlist 모델 전체가 `isKnownModel`로 인식되는지 검증
  - 버전 suffix 모델(`gpt-4.1-mini-2025-04-14`) 비용 계산 검증

## 변경 이유
- 프롬프트 버전에서 선택 가능한 모델과 pricing 테이블이 불일치하여, 토큰은 집계되지만 비용이 0으로 저장되는 케이스가 발생함

## 실행한 검증 명령
- `./gradlew test --tests "com.llm_ops.demo.gateway.pricing.ModelPricingTest"`

## 리스크 및 롤백 포인트
- 리스크: 가격 단가 값이 정책과 다를 수 있음 (정책 변경 시 동시 갱신 필요)
- 롤백 포인트: `ModelPricing`의 신규 모델 3개 엔트리 제거 시 기존 동작으로 즉시 복귀 가능

Closes #184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 AI 모델 버전들에 대한 가격 책정 지원 추가. 입력 및 출력 토큰별 가격 정보가 확장되었습니다.

* **테스트**
  * 모델 지원 검증 및 비용 계산 기능의 안정성을 위해 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->