### PR TITLE
fix: actuator 엔드포인트 permitAll 설정

### DIFF
--- a/src/main/java/com/llm_ops/demo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/llm_ops/demo/auth/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                         ).permitAll()
                         // 게이트웨이 외부 호출(조직 API 키로 인증)
                         .requestMatchers("/v1/chat/**").permitAll()
-                        .requestMatchers("/health", "/actuator/health", "/actuator/prometheus", "/actuator/info").permitAll()
+                        .requestMatchers("/health", "/actuator/health", "/actuator/prometheus").permitAll()
                         // 그 외 모든 요청(로그아웃 포함)은 인증 필요
                         .anyRequest().authenticated())
                 // H2 Console을 위한 frameOptions 설정


### PR DESCRIPTION
## 요약
- 9091 management 포트의 `/actuator/prometheus`가 SecurityFilterChain에 의해 401 반환되는 문제 수정
- `/actuator/health`만 허용하던 것을 `/actuator/**` 전체로 변경

## 변경 내용
- `SecurityConfig.java`: `.requestMatchers("/health", "/actuator/health")` → `.requestMatchers("/health", "/actuator/**")`

## 테스트 계획
- [ ] `curl -s http://localhost:9091/actuator/prometheus` 정상 응답 확인
- [ ] `curl -s http://localhost:9091/actuator/health` 기존 동작 유지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **유지보수**
  * 보안 설정 업데이트: 시스템 상태 확인용 엔드포인트에 대한 무인증 접근 범위가 확대되었습니다. /health 및 /actuator/health 외에 /actuator/prometheus 및 /actuator/info 경로에도 인증 없이 접근할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->