### PR TITLE
fix: Gradle 빌드 캐시 비활성화로 V22 Flyway 체크섬 오류 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build & Test
-        run: ./gradlew clean build -Dspring.profiles.active=test
+        run: ./gradlew clean build --no-build-cache -Dspring.profiles.active=test
 
       # ✅ jar를 다음 job으로 넘겨서 "중복 빌드" 제거
       - name: Upload JAR artifact


### PR DESCRIPTION
## 문제

CI/CD 파이프라인에서 Gradle 빌드 캐시로 인해 수정된 V22 SQL 파일이 jar에 반영되지 않아 Flyway 체크섬 불일치 오류 반복 발생.

```
Migration checksum mismatch for migration version 22
```

## 원인 분석

- `setup-java`의 `cache: gradle` 옵션이 `~/.gradle/caches/build-cache`까지 캐싱
- `clean build`로도 build-cache는 초기화되지 않아 이전 jar의 SQL 리소스가 재사용됨
- EC2에서 실행 중인 jar를 직접 확인하여 캐시된 구버전 V22가 포함된 것 확인

## 수정 내용

- `--no-build-cache` 플래그 추가로 항상 fresh jar 빌드 보장

```yaml
# Before
./gradlew clean build -Dspring.profiles.active=test
# After
./gradlew clean build --no-build-cache -Dspring.profiles.active=test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)