### PR TITLE
fix: eval 모델 호출 타임아웃 120초 상향

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -192,6 +192,6 @@ eval:
     poll-interval-ms: 3000
     batch-size: 3
   runner:
-    request-timeout-ms: 20000
+    request-timeout-ms: 120000
     same-provider-retry-max-attempts: 1
     same-provider-retry-backoff-ms: 200


### PR DESCRIPTION
## 변경 내용
- `eval.runner.request-timeout-ms` 값을 `20000`에서 `120000`으로 상향
- 변경 파일: `src/main/resources/application.yml`

## 변경 이유
- Eval 실행 중 단건 모델 호출이 20초 제한에 걸려 `TIMEOUT_EXCEPTION`이 발생하는 케이스가 있어, 일시 지연 상황에서의 실패율을 낮추기 위함

## 실행한 검증 명령
- 설정값 반영 확인: `rg -n "eval:|runner:|request-timeout-ms" src/main/resources/application.yml`

## 리스크 및 롤백 포인트
- 리스크: 호출 대기 시간이 더 길어져 개별 케이스 처리 지연 가능
- 롤백: `eval.runner.request-timeout-ms`를 `20000`으로 원복

Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프롬프트 템플릿의 변수를 자동으로 인식하고 매핑하는 템플릿 변수 관리 기능 추가
  * 테스트 케이스 상세 정보 패널에서 Context 변수를 더 명확하게 표시

* **개선 사항**
  * 외부 식별자 및 Context JSON 입력 필드의 라벨과 안내 텍스트 개선
  * 템플릿 변수를 배지로 시각화하여 더 쉽게 확인 가능하도록 개선
  * 평가 실행 타임아웃 값 증가 (20초 → 120초)

* **테스트**
  * 템플릿 변수 추출 및 검증 로직에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->