### PR TITLE
feat: add log pagination and status filter mapping

### DIFF
--- a/frontend2/src/api/logs.api.ts
+++ b/frontend2/src/api/logs.api.ts
@@ -8,6 +8,7 @@ export const logsApi = {
       page?: number;
       size?: number;
       status?: string;
+      failover?: boolean;
       provider?: string;
       usedModel?: string;
       ragEnabled?: boolean;
@@ -31,4 +32,3 @@ export const logsApi = {
     return res.data.data;
   },
 };
-

--- a/frontend2/src/pages/logs/WorkspaceLogsPage.tsx
+++ b/frontend2/src/pages/logs/WorkspaceLogsPage.tsx
@@ -6,12 +6,16 @@ import { promptApi } from '@/api/prompt.api';
 import { logsApi } from '@/api/logs.api';
 import type { RequestLogResponse, RequestLogStatus } from '@/types/api.types';
 
-const STATUS_OPTIONS: Array<{ value: 'ALL' | RequestLogStatus; label: string }> = [
-  { value: 'ALL', label: '전체' },
-  { value: 'SUCCESS', label: '성공' },
-  { value: 'FAIL', label: '실패' },
-  { value: 'IN_PROGRESS', label: '진행 중' },
-  { value: 'BLOCKED', label: '차단됨' },
+const PAGE_SIZE = 20;
+
+type LogStatusFilter = 'ALL' | 'SUCCESS' | 'FAILOVER' | 'FAIL' | 'BLOCKED';
+
+const STATUS_OPTIONS: Array<{ value: LogStatusFilter; label: string }> = [
+  { value: 'ALL', label: 'all' },
+  { value: 'SUCCESS', label: 'success' },
+  { value: 'FAILOVER', label: 'failover' },
+  { value: 'FAIL', label: 'fail' },
+  { value: 'BLOCKED', label: 'blocked' },
 ];
 
 function formatShortDateTime(iso: string) {
@@ -71,10 +75,11 @@ export function WorkspaceLogsPage() {
   const defaultPromptKey = prompts?.[0]?.promptKey || '';
 
   const [promptKey, setPromptKey] = useState(searchParams.get('promptKey') || '');
-  const [status, setStatus] = useState<'ALL' | RequestLogStatus>('ALL');
+  const [status, setStatus] = useState<LogStatusFilter>('ALL');
   const [ragEnabled, setRagEnabled] = useState<'ALL' | 'true' | 'false'>('ALL');
   const [provider, setProvider] = useState('');
   const [traceId, setTraceId] = useState('');
+  const [page, setPage] = useState(0);
 
   // Prompt key: URL → state → defaultPromptKey 순서로 초기화
   useEffect(() => {
@@ -85,15 +90,27 @@ export function WorkspaceLogsPage() {
 
   const resolvedParams = useMemo(() => {
     const params: Record<string, unknown> = {
-      page: 0,
-      size: 20,
+      page,
+      size: PAGE_SIZE,
     };
     if (promptKey.trim()) params.promptKey = promptKey.trim();
-    if (status !== 'ALL') params.status = status;
+    if (status === 'SUCCESS') {
+      params.status = 'SUCCESS';
+      params.failover = false;
+    } else if (status === 'FAILOVER') {
+      params.status = 'SUCCESS';
+      params.failover = true;
+    } else if (status !== 'ALL') {
+      params.status = status;
+    }
     if (ragEnabled !== 'ALL') params.ragEnabled = ragEnabled === 'true';
     if (provider.trim()) params.provider = provider.trim();
     if (traceId.trim()) params.traceId = traceId.trim();
     return params;
+  }, [page, promptKey, status, ragEnabled, provider, traceId]);
+
+  useEffect(() => {
+    setPage(0);
   }, [promptKey, status, ragEnabled, provider, traceId]);
 
   const {
@@ -109,6 +126,20 @@ export function WorkspaceLogsPage() {
   });
 
   const logs = list?.content ?? [];
+  const totalElements = list?.totalElements ?? 0;
+  const totalPages = list?.totalPages ?? 0;
+  const currentPage = list?.page ?? page;
+  const pageSize = list?.size ?? PAGE_SIZE;
+  const firstItemIndex = totalElements === 0 ? 0 : currentPage * pageSize + 1;
+  const lastItemIndex = totalElements === 0 ? 0 : currentPage * pageSize + logs.length;
+
+  useEffect(() => {
+    if (!list) return;
+    const maxPage = Math.max(list.totalPages - 1, 0);
+    if (page > maxPage) {
+      setPage(maxPage);
+    }
+  }, [list, page]);
 
   if (!isValidWorkspaceId) {
     return <div className="p-8 text-[var(--text-secondary)]">유효하지 않은 워크스페이스입니다.</div>;
@@ -159,7 +190,7 @@ export function WorkspaceLogsPage() {
             <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">status</label>
             <select
               value={status}
-              onChange={(e) => setStatus(e.target.value as 'ALL' | RequestLogStatus)}
+              onChange={(e) => setStatus(e.target.value as LogStatusFilter)}
               className="w-full rounded-lg border border-[var(--border)] bg-[var(--background-card)] px-3 py-2 text-sm text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
             >
               {STATUS_OPTIONS.map((opt) => (
@@ -220,7 +251,7 @@ export function WorkspaceLogsPage() {
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <div className="text-sm font-medium text-[var(--foreground)]">최근 로그</div>
           <div className="text-xs text-[var(--text-secondary)]">
-            {list ? `총 ${list.totalElements}개 중 상위 ${logs.length}개` : ''}
+            {list ? `총 ${totalElements}개 중 ${firstItemIndex}-${lastItemIndex}개` : ''}
           </div>
         </div>
 
@@ -247,88 +278,133 @@ export function WorkspaceLogsPage() {
             최근 요청이 없습니다. API 호출 후 확인하세요.
           </div>
         ) : (
-          <ul className="divide-y divide-[var(--border)]">
-            {logs.map((log) => (
-              <li key={log.traceId} className="px-4 py-4 transition-colors hover:bg-[var(--surface-subtle)]">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className={statusBadge(log.status)}>{log.status}</span>
-                      {log.isFailover ? (
-                        <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/35 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
-                          FAILOVER
-                        </span>
-                      ) : null}
-                      <span className="text-xs text-[var(--text-secondary)]">
-                        {formatShortDateTime(log.createdAt)}
-                      </span>
-                      <span className="text-xs text-[var(--text-secondary)]">
-                        {log.provider || '-'} · {modelLabel(log)}
-                      </span>
-                      <span className="text-xs text-[var(--text-secondary)]">
-                        HTTP {log.httpStatus ?? '-'}
-                      </span>
-                    </div>
-
-                    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-secondary)]">
-                      <span className="font-mono truncate max-w-[420px]">{log.traceId}</span>
-                      <button
-                        type="button"
-                        onClick={() => navigator.clipboard.writeText(log.traceId)}
-                        className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2 py-1 text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)]"
-                      >
-                        <Copy size={14} />
-                        복사
-                      </button>
-                      <span>latency {log.latencyMs ?? '-'}ms</span>
-                      <span>tokens {log.totalTokens ?? '-'}</span>
-                      <span className="inline-flex items-center gap-1">
-                        <span
-                          className={
-                            log.ragEnabled
-                              ? 'rounded-full border border-indigo-400/35 bg-indigo-500/10 px-2 py-0.5 text-[11px] font-medium text-indigo-700 dark:text-indigo-300'
-                              : 'rounded-full border border-[var(--border)] bg-[var(--surface-subtle)] px-2 py-0.5 text-[11px] font-medium text-[var(--text-secondary)]'
-                          }
-                        >
-                          RAG {log.ragEnabled ? 'on' : 'off'}
-                        </span>
-                        {log.ragEnabled ? (
-                          <span className="text-xs text-[var(--text-secondary)]">
-                            (chunks {log.ragChunksCount ?? '-'} · rag {log.ragLatencyMs ?? '-'}ms)
+          <>
+            <ul className="divide-y divide-[var(--border)]">
+              {logs.map((log) => (
+                <li key={log.traceId} className="px-4 py-4 transition-colors hover:bg-[var(--surface-subtle)]">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className={statusBadge(log.status)}>{log.status}</span>
+                        {log.isFailover ? (
+                          <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/35 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                            FAILOVER
                           </span>
                         ) : null}
-                      </span>
-                      {log.isFailover && log.failReason ? (
-                        <span className="inline-flex items-center gap-1 rounded-md border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-300">
-                          failover {log.failReason}
+                        <span className="text-xs text-[var(--text-secondary)]">
+                          {formatShortDateTime(log.createdAt)}
                         </span>
-                      ) : null}
+                        <span className="text-xs text-[var(--text-secondary)]">
+                          {log.provider || '-'} · {modelLabel(log)}
+                        </span>
+                        <span className="text-xs text-[var(--text-secondary)]">
+                          HTTP {log.httpStatus ?? '-'}
+                        </span>
+                      </div>
+
+                      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-secondary)]">
+                        <span className="font-mono truncate max-w-[420px]">{log.traceId}</span>
+                        <button
+                          type="button"
+                          onClick={() => navigator.clipboard.writeText(log.traceId)}
+                          className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2 py-1 text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)]"
+                        >
+                          <Copy size={14} />
+                          복사
+                        </button>
+                        <span>latency {log.latencyMs ?? '-'}ms</span>
+                        <span>tokens {log.totalTokens ?? '-'}</span>
+                        <span className="inline-flex items-center gap-1">
+                          <span
+                            className={
+                              log.ragEnabled
+                                ? 'rounded-full border border-indigo-400/35 bg-indigo-500/10 px-2 py-0.5 text-[11px] font-medium text-indigo-700 dark:text-indigo-300'
+                                : 'rounded-full border border-[var(--border)] bg-[var(--surface-subtle)] px-2 py-0.5 text-[11px] font-medium text-[var(--text-secondary)]'
+                            }
+                          >
+                            RAG {log.ragEnabled ? 'on' : 'off'}
+                          </span>
+                          {log.ragEnabled ? (
+                            <span className="text-xs text-[var(--text-secondary)]">
+                              (chunks {log.ragChunksCount ?? '-'} · rag {log.ragLatencyMs ?? '-'}ms)
+                            </span>
+                          ) : null}
+                        </span>
+                        {log.isFailover && log.failReason ? (
+                          <span className="inline-flex items-center gap-1 rounded-md border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                            failover {log.failReason}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="shrink-0">
+                      <Link
+                        to={`${basePath}/logs/${log.traceId}`}
+                        className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)]"
+                      >
+                        상세
+                        <ExternalLink size={16} />
+                      </Link>
                     </div>
                   </div>
 
-                  <div className="shrink-0">
-                    <Link
-                      to={`${basePath}/logs/${log.traceId}`}
-                      className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)]"
-                    >
-                      상세
-                      <ExternalLink size={16} />
-                    </Link>
-                  </div>
-                </div>
+                  {log.status === 'FAIL' || log.errorCode || log.errorMessage ? (
+                    <div className="mt-3 rounded-lg border border-rose-400/35 bg-rose-500/10 px-3 py-2 text-xs text-rose-700 dark:text-rose-200">
+                      <span className="font-medium">Error</span>
+                      <span className="ml-2">
+                        {log.errorCode || '-'} {log.errorMessage ? `· ${log.errorMessage}` : ''}
+                        {log.failReason ? ` · failReason=${log.failReason}` : ''}
+                      </span>
+                    </div>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
 
-                {log.status === 'FAIL' || log.errorCode || log.errorMessage ? (
-                  <div className="mt-3 rounded-lg border border-rose-400/35 bg-rose-500/10 px-3 py-2 text-xs text-rose-700 dark:text-rose-200">
-                    <span className="font-medium">Error</span>
-                    <span className="ml-2">
-                      {log.errorCode || '-'} {log.errorMessage ? `· ${log.errorMessage}` : ''}
-                      {log.failReason ? ` · failReason=${log.failReason}` : ''}
-                    </span>
-                  </div>
-                ) : null}
-              </li>
-            ))}
-          </ul>
+            <div className="flex flex-col gap-3 border-t border-[var(--border)] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-xs text-[var(--text-secondary)]">
+                {`총 ${totalElements}개 중 ${firstItemIndex}-${lastItemIndex}개`}
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage(0)}
+                  disabled={currentPage === 0}
+                  className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  처음
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+                  disabled={currentPage === 0}
+                  className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  이전
+                </button>
+                <span className="px-2 text-xs text-[var(--text-secondary)]">
+                  {`${currentPage + 1} / ${Math.max(totalPages, 1)} 페이지`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((prev) => Math.min(prev + 1, Math.max(totalPages - 1, 0)))}
+                  disabled={currentPage >= Math.max(totalPages - 1, 0)}
+                  className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  다음
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage(Math.max(totalPages - 1, 0))}
+                  disabled={currentPage >= Math.max(totalPages - 1, 0)}
+                  className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--surface-elevated)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  마지막
+                </button>
+              </div>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend2/src/pages/logs/WorkspaceLogsPage.tsx
+++ b/frontend2/src/pages/logs/WorkspaceLogsPage.tsx
@@ -9,6 +9,7 @@ import type { RequestLogResponse, RequestLogStatus } from '@/types/api.types';
 const PAGE_SIZE = 20;
 
 type LogStatusFilter = 'ALL' | 'SUCCESS' | 'FAILOVER' | 'FAIL' | 'BLOCKED';
+type LogsListParams = NonNullable<Parameters<typeof logsApi.list>[1]>;
 
 const STATUS_OPTIONS: Array<{ value: LogStatusFilter; label: string }> = [
   { value: 'ALL', label: 'all' },
@@ -89,7 +90,7 @@ export function WorkspaceLogsPage() {
   }, [defaultPromptKey, promptKey]);
 
   const resolvedParams = useMemo(() => {
-    const params: Record<string, unknown> = {
+    const params: LogsListParams = {
       page,
       size: PAGE_SIZE,
     };


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 작업 내용
- 어떤 기능을 구현했는지 혹은 어떤 문제를 해결했는지 적어주세요.
- 주요 변경 사항을 요약해주세요.

## 📸 스크린샷 (선택)
- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부해주세요.

## 📚 레퍼런스 (선택)
- 참고한 링크나 문서가 있다면 적어주세요.

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그 목록에 페이지네이션 기능이 추가되었습니다.
  * 장애조치(페일오버) 상태 필터링 옵션이 추가되었습니다.
  * 페일오버를 쿼리로 전달하는 옵션이 지원됩니다.
  * 페이지네이션 컨트롤(처음, 이전, 다음, 마지막)이 추가되었습니다.
  * 로그 표시가 개선되어 상태 배지, 타임스탬프, 제공자, 모델, HTTP 상태, 추적 ID(복사), 지연시간, 토큰, RAG 상태 및 페일오버 이유가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->