### PR TITLE
docs: README 팀 소개 GitHub 프로필 카드 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,49 @@ Logs 화면에서는 정상 요청과 failover 요청을 같은 목록 안에서
 
 ## 팀 소개 및 역할
 
-| 이름 | 역할 | 담당 |
-| --- | --- | --- |
-| 허지우 | 팀장 · Backend | Gateway 호출 흐름, Retry/Failover 정책, Prompt 운영 구조, LLM Provider 연동 |
-| 홍찬용 | Backend · Infra | Prompt·Workspace·Organization 도메인 설계·구현, AWS EC2·RDS·ALB 배포 |
-| 박준하 | Backend · Observability | 요청 로그/Trace 조회, 통계 대시보드, 인증 및 보안 영역 |
+<table width="100%">
+  <tr>
+    <th width="33.33%">Backend · Team Lead</th>
+    <th width="33.33%">Backend · Infra</th>
+    <th width="33.33%">Backend · Observability</th>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/itsjiwootime">
+        <img src="https://github.com/itsjiwootime.png?size=120" width="120" height="120" alt="허지우">
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/chanyong1027">
+        <img src="https://github.com/chanyong1027.png?size=120" width="120" height="120" alt="홍찬용">
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/Joooooonha">
+        <img src="https://github.com/Joooooonha.png?size=120" width="120" height="120" alt="박준하">
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/itsjiwootime"><strong>허지우</strong></a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/chanyong1027"><strong>홍찬용</strong></a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/Joooooonha"><strong>박준하</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <sub>Gateway 호출 흐름, Retry/Failover 정책, Prompt 운영 구조, LLM Provider 연동</sub>
+    </td>
+    <td align="center">
+      <sub>Prompt·Workspace·Organization 도메인 설계·구현, AWS EC2·RDS·ALB 배포</sub>
+    </td>
+    <td align="center">
+      <sub>요청 로그/Trace 조회, 통계 대시보드, 인증 및 보안 영역</sub>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## 📌 관련 이슈
- 없음

## ✨ 작업 내용
- README 하단 팀 소개 섹션을 GitHub 프로필 이미지 기반 카드형 표로 변경했습니다.
- 각 멤버 아바타를 동일한 `120x120` 크기로 고정하고 열 너비를 균등하게 맞췄습니다.
- 이름은 각 GitHub 프로필 링크로 연결되도록 구성했습니다.

## 🧭 변경 이유
- 기존 텍스트 표보다 팀 구성이 더 직관적으로 보이도록 정리했습니다.
- GitHub PR/README 화면에서 실제 렌더링 기준으로 정렬 상태를 확인하기 쉽도록 만들었습니다.

## ✅ 실행한 검증 명령
- `git diff --check`

## ⚠️ 리스크 및 롤백 포인트
- README 마크업만 변경되어 런타임 영향은 없습니다.
- GitHub 렌더링에서 표 배치가 기대와 다르면 기존 Markdown 표로 쉽게 되돌릴 수 있습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- GitHub profile images (`https://github.com/<id>.png?size=120`)

## ✅ 체크리스트
- [ ] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* README의 팀 섹션이 업데이트되었습니다. Markdown 테이블이 HTML 테이블로 변경되어 정보 표시가 개선되었습니다.
* 백엔드 팀의 세 가지 역할(Team Lead, Infra, Observability)이 명확하게 구분됩니다.
* 각 팀 멤버의 아바타 이미지와 GitHub 프로필 링크가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->