### PR TITLE
refactor: prompt eval parallel execution (#245)

### DIFF
--- a/docs/prompt-eval-benchmark-2026-03-18.md
+++ b/docs/prompt-eval-benchmark-2026-03-18.md
@@ -314,23 +314,57 @@
 - 5건 burst에서는 `4`가 평균 queue 대기만 줄였고, 평균/최대 완료 시간은 `3`보다 약 `10%` 나빴다.
 - 원인은 현재 `case per run = 2`, `global active cases = 6`, `openai permits = 4` 상한이 먼저 걸리기 때문이다. run만 더 열면 completion 단계에서 경합이 늘어난다.
 
-권장 기본값:
+중간 결론(3건/5건 burst 기준):
 
 - `eval.worker.max-concurrent-runs = 3`
 - `eval.execution.max-concurrent-cases-per-run = 2`
 - `eval.execution.max-active-cases-global = 6`
 - `eval.runner.provider-limits.openai-max-concurrent-calls = 4`
 
-## 17. 남은 튜닝 포인트
+## 17. 후속 튜닝: `10건 burst` + case/provider limiter 상향
+
+추가 튜닝 목적:
+
+- `run=3`까지는 정리됐지만, 10건 burst에서는 여전히 뒤 run 대기가 컸다.
+- 그래서 `case/global/provider` limiter를 함께 올렸을 때 실제 completion이 줄어드는지 확인했다.
+
+비교 설정:
+
+- 기본값: `run=3`, `case=2`, `global=6`, `openai=4`
+- 튜닝값: `run=3`, `case=3`, `global=9`, `openai=6`
+
+### 10건 burst 비교
+
+| 설정 | 평균 queue 대기 | 최대 queue 대기 | 평균 완료 시간 | 최대 완료 시간 | 평균 비용 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 기본값 | 27.538s | 62.179s | 48.564s | 79.854s | $0.005266 |
+| 튜닝값 1차 | 17.541s | 40.524s | 32.064s | 54.004s | $0.005114 |
+| 튜닝값 2차 | 18.013s | 41.582s | 33.529s | 53.414s | $0.005054 |
+
+해석:
+
+- 튜닝값은 10건 burst에서 평균 queue 대기 `-34% ~ -36%`, 평균 완료 시간 `-31% ~ -34%` 수준으로 일관되게 개선됐다.
+- 최대 완료 시간도 `79.854s -> 54.004s / 53.414s`로 `약 32%` 줄었다.
+- 두 번 모두 `10/10 COMPLETED`였고, 이번 측정에서는 run 실패나 429 증가가 관찰되지 않았다.
+- 즉 현재 장기 적체 구간에서는 `run 슬롯`보다 `case/global/provider` limiter가 실제 병목으로 작동하고 있었다.
+
+권장 운영 기본값:
+
+- `eval.worker.max-concurrent-runs = 3`
+- `eval.execution.max-concurrent-cases-per-run = 3`
+- `eval.execution.max-active-cases-global = 9`
+- `eval.runner.provider-limits.openai-max-concurrent-calls = 6`
+
+## 18. 남은 튜닝 포인트
 
 - `max-concurrent-runs`는 `3`으로 올리는 것이 현재 설정 조합에서 가장 균형이 좋다.
-- 다음 병목 후보는 `run 슬롯`보다 `global case limiter`와 `provider permit`이다.
-- `max-concurrent-cases-per-run` 또는 provider permit 상향은 429 / 비용 / completion 분산을 같이 보면서 별도로 확인해야 한다.
-- 동일 시나리오로 `10건` burst를 추가 측정하면 장기 적체 구간을 더 잘 볼 수 있다.
+- `case/global/provider`를 올린 현재 권장값 기준으로는 다음 검증 포인트가 `20건` 이상 장기 burst와 provider 에러율이다.
+- OpenAI permit을 `6`으로 올린 상태에서 더 큰 burst를 걸면 429/timeout이 다시 생길 수 있으니 상한 탐색은 점진적으로 해야 한다.
+- provider별 비용 변화와 Hikari/DB 경합도 함께 보면서 조정해야 한다.
 
-## 18. 최종 결론
+## 19. 최종 결론
 
 - 병렬화 적용 후 Prompt Eval은 단건 기준 평균 완료 시간이 `32.988s -> 22.418s`로 줄었다.
-- 후속 튜닝까지 포함하면 운영 기본값은 `max-concurrent-runs = 3`이 가장 적절하다.
-- 3건 enqueue burst 기준 평균 완료 시간은 `44.115s -> 21.520s`, 최대 완료 시간은 `56.666s -> 22.852s`까지 추가 개선됐다.
-- 현재 병목의 중심은 더 이상 HTTP ingress가 아니라 `global case limiter`, `provider concurrency`, 그리고 외부 LLM 호출 시간이다.
+- 후속 튜닝까지 포함하면 운영 기본값은 `run=3 / case=3 / global=9 / openai=6` 조합이 가장 적절했다.
+- 10건 burst 기준 평균 완료 시간은 `48.564s -> 32.064s`, 최대 완료 시간은 `79.854s -> 54.004s`까지 추가 개선됐다.
+- 현재 병목의 중심은 HTTP ingress가 아니라 `global case limiter`, `provider concurrency`, 그리고 외부 LLM 호출 시간이다.

--- a/docs/prompt-eval-benchmark-2026-03-18.md
+++ b/docs/prompt-eval-benchmark-2026-03-18.md
@@ -1,0 +1,298 @@
+# Prompt Eval Benchmark (2026-03-18)
+
+## 1. 목적
+
+- 현재 `develop` 기준 Prompt Eval 실행 경로의 성능 baseline을 확보한다.
+- 병렬 처리 적용 전, 여러 사용자가 동시에 Eval 실행을 요청했을 때 queue 적체가 얼마나 커지는지 확인한다.
+- 이력서/면접 답변용으로 환경, 부하 조건, 해석 기준을 명시 가능한 수치를 남긴다.
+
+## 2. 전제와 주의
+
+- 이 문서는 `Gateway` 부하 테스트 결과가 아니라 `Prompt Eval` 실행 경로 측정 결과다.
+- 이번 측정은 `Prompt Eval` 기준이다. `POST /eval/runs`는 비동기 enqueue API이고, 실제 평가는 Worker가 백그라운드에서 처리한다.
+- 서버는 `prod,test-perf` 프로필로 실행했지만, `Prompt Eval`은 `test-perf`의 Gateway stub을 사용하지 않는다.
+  - `test-perf` stub은 Gateway용 `ChatModel` 대체 구성이다.
+  - Prompt Eval은 `EvalModelRunnerService`에서 실제 provider API를 직접 호출한다.
+- 따라서 이번 측정에는 실제 OpenAI API 호출 비용이 포함된다.
+
+## 3. 측정 환경
+
+- OS: macOS 26.1
+- CPU: Apple M4
+- Memory: 16GB
+- Backend: Spring Boot, `http://localhost:8081`
+- DB: Docker PostgreSQL (`localhost:5433`)
+- Object Storage: Docker MinIO (`localhost:9000-9001`)
+- Candidate model: `OPENAI / gpt-4.1-mini`
+- Judge model: `OPENAI / gpt-4.1-mini`
+- Eval mode: `CANDIDATE_ONLY`
+- Rubric: `SUMMARY`
+- Prompt: no-RAG 요약 프롬프트
+- Dataset: 5 cases
+- Worker 설정:
+  - `eval.worker.poll-interval-ms = 3000`
+  - `eval.worker.batch-size = 3`
+
+## 4. 현재 코드 기준 병목 위치
+
+- Worker는 3초마다 queue를 polling 한다.
+- Worker는 queue에서 run을 꺼낸 뒤 `EvalExecutionService.processRun()`을 호출한다.
+- `processRun()` 내부에서 case 목록을 `for` 루프로 순차 처리한다.
+- `pickQueuedRuns(batchSize=3)`는 최대 3개 run을 한 번에 `RUNNING`으로 마킹한다.
+
+즉, 현재 구조는:
+
+1. `POST /eval/runs` 요청 자체는 빠르게 수신한다.
+2. 실제 Prompt Eval 처리 throughput은 낮다.
+3. 여러 run이 동시에 들어오면 실패하기보다 queue 대기 시간이 커진다.
+
+## 5. 측정 대상
+
+### 공통 조건
+
+- 프롬프트 버전: `gpt-4.1-mini`, `temperature=0.0`, `maxOutputTokens=120`
+- Dataset: 5건
+- test case 유형: 한국어 요약 1문장 생성
+- 평가 mode: `CANDIDATE_ONLY`
+- 평가 rubric: `SUMMARY`
+
+### 테스트 케이스 수
+
+- 각 run은 5 cases를 처리한다.
+- Judge 재시도 설정은 기본값을 따른다.
+  - `rejudge-on-fail = true`
+  - `max-attempts = 2`
+
+## 6. 사전 Estimate 결과
+
+`POST /eval/runs:estimate` 기준:
+
+- estimated calls: `11 ~ 16`
+- estimated tokens: `2701 ~ 6214`
+- estimated cost: `$0.002280 ~ $0.006662`
+- estimated duration: `16.5s ~ 44.8s`
+
+실측 비용은 run당 약 `$0.0052 ~ $0.0054` 수준으로 estimate 범위 안에 들어왔다.
+
+## 7. 시나리오 A: 단일 run baseline
+
+### 부하 조건
+
+- 동시 run 수: `1`
+- 방식: 한 run이 완료된 뒤 다음 run을 생성
+- 반복 횟수: 3회
+
+### 결과
+
+| Run ID | Created -> Started (s) | Started -> Completed (s) | Created -> Completed (s) | Total Cost (USD) |
+| --- | ---: | ---: | ---: | ---: |
+| 210 | 3.067 | 30.295 | 33.362 | 0.005408 |
+| 211 | 1.657 | 30.345 | 32.002 | 0.005229 |
+| 212 | 2.392 | 31.209 | 33.601 | 0.005269 |
+
+### 요약
+
+- 평균 완료 시간 (`Created -> Completed`): `32.988s`
+- 최대 완료 시간: `33.601s`
+- 평균 queue 대기 (`Created -> Started`): `2.372s`
+- 평균 처리 구간 (`Started -> Completed`): `30.616s`
+- 평균 비용: `$0.005302 / run`
+
+## 8. 시나리오 B: Artillery로 run enqueue 부하
+
+### 부하 조건
+
+- 도구: `Artillery`
+- 대상 API: `POST /api/v1/workspaces/{workspaceId}/prompts/{promptId}/eval/runs`
+- 부하 기준: `arrivalRate = 1 rps`, `duration = 3s`
+- 총 생성 요청 수: `3`
+
+주의:
+
+- 이 시나리오는 `VU(동시 접속자 수)` 기준보다는 `run enqueue rate` 기준이다.
+- HTTP 요청은 즉시 반환되고 실제 평가는 비동기 Worker가 수행하므로, `Prompt Eval`은 VU보다 queue 적체를 보는 것이 더 중요하다.
+
+### Artillery API 응답 요약
+
+- `HTTP 201`: `3/3`
+- mean response time: `30.3ms`
+- p95 response time: `32.8ms`
+- max response time: `36ms`
+
+즉, `POST /eval/runs` API 자체는 빠르게 응답했다.
+
+### enqueue 이후 실제 run 결과
+
+| Run ID | Status | Created -> Started (s) | Started -> Completed (s) | Created -> Completed (s) | Total Cost (USD) |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 213 | COMPLETED | 0.820 | 30.747 | 31.567 | 0.005220 |
+| 214 | COMPLETED | 33.585 | 25.742 | 59.327 | 0.005260 |
+| 215 | COMPLETED | 32.589 | 63.980 | 96.569 | 0.005106 |
+
+### 요약
+
+- 평균 queue 대기 (`Created -> Started`): `22.331s`
+- 최대 queue 대기: `33.585s`
+- 평균 완료 시간 (`Created -> Completed`): `62.488s`
+- 최대 완료 시간: `96.569s`
+- 평균 비용: `$0.005195 / run`
+
+## 9. 해석
+
+### 9.1 API ingress는 병목이 아니다
+
+- `POST /eval/runs` 자체는 평균 `30.3ms`로 매우 빨랐다.
+- 즉 요청 접수 capacity보다, 백그라운드 Eval 처리 throughput이 현재 병목이다.
+
+### 9.2 현재 Prompt Eval의 실질 동시 처리량은 낮다
+
+- 단건 baseline은 약 `33초` 수준이다.
+- 그러나 거의 동시에 3건을 enqueue하면 뒤 run의 완료 시간은 `59.327s`, `96.569s`까지 늘어난다.
+- 현재 구조는 요청을 빠르게 받되, 실제 처리는 queue에 쌓아 순차적으로 소화하는 형태에 가깝다.
+
+### 9.3 `startedAt` 해석에는 주의가 필요하다
+
+- Worker는 `batchSize=3` 범위의 queued run을 한 번에 `RUNNING`으로 마킹한다.
+- 따라서 `startedAt`은 "실제 compute가 시작된 시점"이라기보다 "Worker가 batch로 claim한 시점"에 가깝다.
+- 여러 run이 동시에 들어온 경우, 사용자 체감 SLA는 `Started -> Completed`보다 `Created -> Completed`를 보는 것이 더 정확하다.
+
+## 10. 결론
+
+- 현재 `develop`의 Prompt Eval은 단건 5-case run 기준 약 `33초` 수준이다.
+- 여러 사용자가 동시에 Eval 실행을 요청하면 API는 빠르게 응답하지만, queue 적체 때문에 뒤 run의 완료 시간이 크게 증가한다.
+- 이번 측정에서 3건 enqueue 시 최대 완료 시간은 `96.569초`였다.
+- 따라서 현재 구조의 문제는 HTTP 동시 접속 처리보다 `Eval Worker / run-case 처리 throughput`에 있다.
+
+## 11. 후속 개선 방향
+
+- run-level concurrency 추가
+- case-level concurrency 추가
+- provider별 동시성 제한 및 rate limiting
+- `QUEUED / CLAIMED / RUNNING` 상태 전이 정교화
+- UI에 queue position, 예상 대기 시간, cancel 흐름 노출
+
+## 12. 병렬화 적용 후 재측정
+
+### 적용 범위
+
+- `QUEUED -> CLAIMED -> RUNNING` 상태 전이 분리
+- bounded `run executor` / `case executor` 도입
+- provider별 동시성 제한 추가
+- cancel / recovery / lease 처리 보강
+
+### 재측정 환경
+
+- 측정 일시: `2026-03-18`
+- 서버 프로필: `prod`
+- Backend: Spring Boot, `http://localhost:8081`
+- Candidate model: `OPENAI / gpt-4.1-mini`
+- Judge model: `OPENAI / gpt-4.1-mini`
+- Eval mode: `CANDIDATE_ONLY`
+- Rubric: `SUMMARY`
+- Dataset: 5 cases
+- 실행 설정:
+  - `eval.worker.poll-interval-ms = 3000`
+  - `eval.worker.max-concurrent-runs = 2`
+  - `eval.execution.max-concurrent-cases-per-run = 2`
+  - `eval.execution.max-active-cases-global = 6`
+  - `eval.runner.provider-limits.openai-max-concurrent-calls = 4`
+
+주의:
+
+- 병렬화 후 재측정은 `prod` 프로필로 수행했다.
+- 초기 기준선은 `prod,test-perf`로 수행했지만, Prompt Eval은 Gateway stub을 사용하지 않고 `EvalModelRunnerService`에서 provider를 직접 호출하므로 비교 축은 유지된다.
+
+## 13. 시나리오 C: 병렬화 후 단일 run baseline
+
+### 부하 조건
+
+- 동시 run 수: `1`
+- 방식: 한 run이 완료된 뒤 다음 run을 생성
+- 반복 횟수: 3회
+
+### 결과
+
+| Run ID | HTTP Create (ms) | Created -> Started (s) | Started -> Completed (s) | Created -> Completed (s) | Total Cost (USD) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 218 | 159.7 | 0.687 | 23.194 | 23.881 | 0.004934 |
+| 219 | 61.8 | 2.949 | 19.901 | 22.850 | 0.005015 |
+| 220 | 31.9 | 0.351 | 20.172 | 20.523 | 0.005021 |
+
+### 요약
+
+- 평균 API 응답: `84.5ms`
+- 평균 queue 대기 (`Created -> Started`): `1.329s`
+- 평균 처리 구간 (`Started -> Completed`): `21.089s`
+- 평균 완료 시간 (`Created -> Completed`): `22.418s`
+- 최대 완료 시간: `23.881s`
+- 평균 비용: `$0.004990 / run`
+
+## 14. 시나리오 D: 병렬화 후 Artillery run enqueue 부하
+
+### 부하 조건
+
+- 도구: `Artillery`
+- 대상 API: `POST /api/v1/workspaces/{workspaceId}/prompts/{promptId}/eval/runs`
+- 부하 기준: `arrivalRate = 1 rps`, `duration = 3s`
+- 총 생성 요청 수: `3`
+
+### Artillery API 응답 요약
+
+- `HTTP 201`: `3/3`
+- mean response time: `43.3ms`
+- p95 response time: `36.2ms`
+- max response time: `64ms`
+
+### enqueue 이후 실제 run 결과
+
+| Run ID | Status | Created -> Started (s) | Started -> Completed (s) | Created -> Completed (s) | Total Cost (USD) |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 221 | COMPLETED | 1.744 | 36.004 | 37.748 | 0.004951 |
+| 222 | COMPLETED | 0.774 | 37.157 | 37.931 | 0.004989 |
+| 223 | COMPLETED | 35.821 | 20.845 | 56.666 | 0.005103 |
+
+### 요약
+
+- 평균 queue 대기 (`Created -> Started`): `12.780s`
+- 최대 queue 대기: `35.821s`
+- 평균 완료 시간 (`Created -> Completed`): `44.115s`
+- 최대 완료 시간: `56.666s`
+- 평균 비용: `$0.005014 / run`
+
+## 15. 병렬화 전/후 비교
+
+| 항목 | 변경 전 | 변경 후 | 변화 |
+| --- | ---: | ---: | ---: |
+| 단건 평균 완료 시간 | 32.988s | 22.418s | -32.0% |
+| 단건 최대 완료 시간 | 33.601s | 23.881s | -28.9% |
+| 단건 평균 queue 대기 | 2.372s | 1.329s | -44.0% |
+| 3건 burst 평균 완료 시간 | 62.488s | 44.115s | -29.4% |
+| 3건 burst 최대 완료 시간 | 96.569s | 56.666s | -41.3% |
+| 3건 burst 평균 queue 대기 | 22.331s | 12.780s | -42.8% |
+| Artillery API 평균 응답 | 30.3ms | 43.3ms | +13.0ms |
+
+해석:
+
+- API ingress는 여전히 병목이 아니다. 응답 시간은 소폭 증가했지만 여전히 `43.3ms` 수준이다.
+- 병렬화 후 핵심 개선은 `queue wait`와 `최대 완료 시간` 감소다.
+- 단건 처리 시간도 같이 줄어들었고, 3건 burst 시 평균/최대 완료 시간이 모두 유의미하게 내려갔다.
+- 비용은 run당 `~$0.0050` 수준으로 유지되어, 성능 개선이 비용 급증으로 이어지지는 않았다.
+
+## 16. 남은 병목과 다음 튜닝 포인트
+
+- 현재 `eval.worker.max-concurrent-runs = 2`라서 3건 burst에서 세 번째 run(`223`)은 여전히 대기한다.
+- `223`의 `Created -> Started = 35.821s`는 run 슬롯 2개가 먼저 차면서 발생한 대기다.
+- 즉 "완전한 병렬 소화"가 아니라 "제한된 병렬 처리"로 개선된 상태다.
+
+다음 튜닝 후보:
+
+- `max-concurrent-runs` 상향 여부 검토
+- `max-concurrent-cases-per-run` 상향 시 provider 429 / 비용 변화 재확인
+- 동일 시나리오로 `5건`, `10건` burst 추가 측정
+
+## 17. 최종 결론
+
+- 병렬화 적용 후 Prompt Eval은 단건 기준 평균 완료 시간이 `32.988s -> 22.418s`로 줄었다.
+- 3건 enqueue burst 기준 최대 완료 시간은 `96.569s -> 56.666s`로 크게 감소했다.
+- queue 적체는 여전히 존재하지만, 이전의 순차 실행 구조 대비 병목이 분명히 완화됐다.
+- 현재 병목의 중심은 "HTTP ingress"가 아니라 "제한된 run 슬롯 수"와 "외부 LLM 호출 시간"이다.

--- a/docs/prompt-eval-benchmark-2026-03-18.md
+++ b/docs/prompt-eval-benchmark-2026-03-18.md
@@ -192,7 +192,7 @@
 - Dataset: 5 cases
 - 실행 설정:
   - `eval.worker.poll-interval-ms = 3000`
-  - `eval.worker.max-concurrent-runs = 2`
+  - `eval.worker.max-concurrent-runs = 2` (초기 재측정 시점)
   - `eval.execution.max-concurrent-cases-per-run = 2`
   - `eval.execution.max-active-cases-global = 6`
   - `eval.runner.provider-limits.openai-max-concurrent-calls = 4`
@@ -278,21 +278,59 @@
 - 단건 처리 시간도 같이 줄어들었고, 3건 burst 시 평균/최대 완료 시간이 모두 유의미하게 내려갔다.
 - 비용은 run당 `~$0.0050` 수준으로 유지되어, 성능 개선이 비용 급증으로 이어지지는 않았다.
 
-## 16. 남은 병목과 다음 튜닝 포인트
+## 16. 후속 튜닝: `max-concurrent-runs` 3 vs 4
 
-- 현재 `eval.worker.max-concurrent-runs = 2`라서 3건 burst에서 세 번째 run(`223`)은 여전히 대기한다.
-- `223`의 `Created -> Started = 35.821s`는 run 슬롯 2개가 먼저 차면서 발생한 대기다.
-- 즉 "완전한 병렬 소화"가 아니라 "제한된 병렬 처리"로 개선된 상태다.
+추가 튜닝 목적:
 
-다음 튜닝 후보:
+- `max-concurrent-runs = 2`에서는 3건 burst에서 세 번째 run(`223`)이 `35.821s` 대기했다.
+- 그래서 운영 기본값 후보로 `3`, `4`를 같은 조건에서 다시 비교했다.
 
-- `max-concurrent-runs` 상향 여부 검토
-- `max-concurrent-cases-per-run` 상향 시 provider 429 / 비용 변화 재확인
-- 동일 시나리오로 `5건`, `10건` burst 추가 측정
+측정 환경:
 
-## 17. 최종 결론
+- 프로필: `prod`
+- 데이터셋: `5 cases`
+- 모델: `OPENAI / gpt-4.1-mini`
+- burst 간격: `1초`
+
+### 3건 burst 비교
+
+| 설정 | 평균 queue 대기 | 최대 queue 대기 | 평균 완료 시간 | 최대 완료 시간 |
+| --- | ---: | ---: | ---: | ---: |
+| `max-concurrent-runs = 2` | 12.780s | 35.821s | 44.115s | 56.666s |
+| `max-concurrent-runs = 3` | 2.738s | 3.693s | 21.520s | 22.852s |
+| `max-concurrent-runs = 4` | 2.329s | 3.286s | 22.053s | 23.489s |
+
+### 5건 burst 비교
+
+| 설정 | 평균 queue 대기 | 최대 queue 대기 | 평균 완료 시간 | 최대 완료 시간 |
+| --- | ---: | ---: | ---: | ---: |
+| `max-concurrent-runs = 3` | 8.178s | 17.360s | 23.532s | 32.126s |
+| `max-concurrent-runs = 4` | 6.143s | 19.713s | 26.016s | 35.459s |
+
+해석:
+
+- `2 -> 3`은 분명한 개선이다. 3건 burst 기준 평균 완료 시간이 `44.115s -> 21.520s`로 절반 가까이 줄었다.
+- `3 -> 4`는 시작 대기는 소폭 줄지만, 완료 시간은 오히려 약간 악화됐다.
+- 5건 burst에서는 `4`가 평균 queue 대기만 줄였고, 평균/최대 완료 시간은 `3`보다 약 `10%` 나빴다.
+- 원인은 현재 `case per run = 2`, `global active cases = 6`, `openai permits = 4` 상한이 먼저 걸리기 때문이다. run만 더 열면 completion 단계에서 경합이 늘어난다.
+
+권장 기본값:
+
+- `eval.worker.max-concurrent-runs = 3`
+- `eval.execution.max-concurrent-cases-per-run = 2`
+- `eval.execution.max-active-cases-global = 6`
+- `eval.runner.provider-limits.openai-max-concurrent-calls = 4`
+
+## 17. 남은 튜닝 포인트
+
+- `max-concurrent-runs`는 `3`으로 올리는 것이 현재 설정 조합에서 가장 균형이 좋다.
+- 다음 병목 후보는 `run 슬롯`보다 `global case limiter`와 `provider permit`이다.
+- `max-concurrent-cases-per-run` 또는 provider permit 상향은 429 / 비용 / completion 분산을 같이 보면서 별도로 확인해야 한다.
+- 동일 시나리오로 `10건` burst를 추가 측정하면 장기 적체 구간을 더 잘 볼 수 있다.
+
+## 18. 최종 결론
 
 - 병렬화 적용 후 Prompt Eval은 단건 기준 평균 완료 시간이 `32.988s -> 22.418s`로 줄었다.
-- 3건 enqueue burst 기준 최대 완료 시간은 `96.569s -> 56.666s`로 크게 감소했다.
-- queue 적체는 여전히 존재하지만, 이전의 순차 실행 구조 대비 병목이 분명히 완화됐다.
-- 현재 병목의 중심은 "HTTP ingress"가 아니라 "제한된 run 슬롯 수"와 "외부 LLM 호출 시간"이다.
+- 후속 튜닝까지 포함하면 운영 기본값은 `max-concurrent-runs = 3`이 가장 적절하다.
+- 3건 enqueue burst 기준 평균 완료 시간은 `44.115s -> 21.520s`, 최대 완료 시간은 `56.666s -> 22.852s`까지 추가 개선됐다.
+- 현재 병목의 중심은 더 이상 HTTP ingress가 아니라 `global case limiter`, `provider concurrency`, 그리고 외부 LLM 호출 시간이다.

--- a/docs/prompt-eval-parallelization-plan.md
+++ b/docs/prompt-eval-parallelization-plan.md
@@ -1,0 +1,534 @@
+# Prompt Eval Parallelization Plan
+
+## 1. 목적
+
+- Prompt Eval의 비동기 enqueue 구조는 유지하되, 실제 실행부를 제한된 병렬 처리 구조로 재설계한다.
+- 여러 사용자가 동시에 Eval을 실행해도 `Created -> Completed` 지연이 선형으로 늘어나지 않도록 한다.
+- 단일 인스턴스뿐 아니라 향후 다중 인스턴스 환경에서도 안전하게 동작하는 상태 전이와 claim 구조를 만든다.
+- 외부 LLM provider의 rate limit, 비용 급증, DB 경합을 통제 가능한 범위 안에서 병렬성을 높인다.
+
+## 2. 현재 문제 요약
+
+- `POST /eval/runs`는 빠르게 enqueue되지만 실제 처리는 워커가 순차 실행한다.
+- 워커는 run 여러 개를 한 번에 `RUNNING`으로 선점하지만, 실제 실행은 순차라 `startedAt`이 실제 compute 시작 시각을 정확히 반영하지 못한다.
+- run 내부에서도 case를 `for` 루프로 하나씩 처리한다.
+- 현재 구조에서는 queue 적체가 커질수록 뒤 run의 완료 시간이 크게 증가한다.
+- case 완료마다 run 엔티티 카운터를 직접 갱신하는 방식은 병렬 case 실행 시 lost update 위험이 있다.
+
+### 변경 전 기준선
+
+아래 수치는 병렬화 전 기준선으로 유지하며, 변경 후 반드시 같은 조건으로 재측정해 비교한다.
+
+- 단건 평균 완료 시간: `32.988s`
+- 3건 enqueue 후 평균 완료 시간: `62.488s`
+- 3건 enqueue 후 최대 완료 시간: `96.569s`
+- queue 대기 평균: `22.331s`
+- API 응답 평균: `30.3ms`
+
+기준 시나리오:
+
+- 단건 baseline: 5-case run 기준 3회 반복
+- enqueue burst: `arrivalRate = 1 rps`, `duration = 3s`, 총 3건 생성
+- 측정 기준: `Created -> Completed`, `Created -> Started`, HTTP 응답 시간
+
+## 3. 최종 목표 구조
+
+```text
+HTTP createRun
+-> DB enqueue (run=QUEUED, cases=QUEUED)
+-> Dispatcher poll
+-> DB claim (QUEUED -> CLAIMED)
+-> Run Executor submit
+-> actual start (CLAIMED -> RUNNING)
+-> Case tasks submit to global case executor
+-> Provider limiter acquire
+-> candidate / baseline / judge calls
+-> case result persist
+-> run summary + overall review
+-> COMPLETED / FAILED / CANCELLED
+```
+
+핵심 원칙:
+
+- HTTP 요청은 계속 짧게 끝낸다.
+- 큐는 유지하되, 실행은 제한된 병렬 처리로 바꾼다.
+- 병렬성은 `run-level`, `case-level`, `provider-level` 3단계에서 각각 제한한다.
+- 상태값과 timestamp는 "실제 상태"를 정확히 반영해야 한다.
+
+## 4. 상태 모델 재설계
+
+### Run 상태
+
+기존:
+
+- `QUEUED`
+- `RUNNING`
+- `COMPLETED`
+- `FAILED`
+- `CANCELLED`
+
+변경:
+
+- `QUEUED`
+- `CLAIMED`
+- `RUNNING`
+- `CANCEL_REQUESTED`
+- `COMPLETED`
+- `FAILED`
+- `CANCELLED`
+
+### 상태 의미
+
+- `QUEUED`: 아직 어떤 실행기에도 할당되지 않음
+- `CLAIMED`: 실행 슬롯은 확보했지만 실제 run compute는 아직 시작되지 않음
+- `RUNNING`: 실제 run 처리 시작, timeout 기준 시각도 이때부터 계산
+- `CANCEL_REQUESTED`: 실행 중 취소 요청 수신, 새 case 스케줄링 중단
+- `COMPLETED` / `FAILED` / `CANCELLED`: 종료 상태
+
+### timestamp/lease 필드
+
+`eval_runs`에 아래 필드 추가를 권장한다.
+
+- `claimed_at`
+- `lease_owner`
+- `lease_expires_at`
+- `last_heartbeat_at`
+- `cancel_requested_at`
+
+의미:
+
+- `started_at`: 실제 run compute 시작 시각
+- `claimed_at`: dispatcher가 실행 슬롯을 예약한 시각
+- `lease_expires_at`: 프로세스 장애 시 stale claim/run을 회수하기 위한 만료 시각
+- `last_heartbeat_at`: 실행기가 살아 있는지 확인하기 위한 heartbeat 시각
+
+## 5. 큐와 워커 구조 재설계
+
+### 5.1 Dispatcher 도입
+
+현재 `EvalWorker`의 역할을 둘로 분리한다.
+
+- `EvalRunDispatcher`
+- `EvalRunExecutionService`
+
+`EvalRunDispatcher`의 책임:
+
+- 주기적으로 큐를 확인
+- 현재 실행 가능 슬롯 수 계산
+- 그 수만큼만 run claim
+- claim된 run을 run executor에 제출
+
+중요:
+
+- 더 이상 `batchSize=3`처럼 고정 개수 선점이 아니라, `executor 남은 슬롯 수` 기준으로 claim한다.
+- `CLAIMED`만 하고 실제 `RUNNING` 전환은 executor 스레드가 일을 시작할 때 수행한다.
+
+### 5.2 안전한 claim 방식
+
+현재의 `PESSIMISTIC_WRITE + saveAll` 패턴 대신, PostgreSQL 기준으로 `SKIP LOCKED` 성격의 claim 로직을 사용한다.
+
+목표:
+
+- 여러 dispatcher 스레드 또는 여러 서버 인스턴스가 동시에 떠도 같은 run을 중복 claim하지 않음
+- queue head blocking 최소화
+- stale `CLAIMED`/`RUNNING` run만 재회수 가능
+
+권장 구현:
+
+- native query 또는 DB 친화적 claim repository 메서드 추가
+- 한 트랜잭션 안에서 `QUEUED -> CLAIMED` 전이와 lease 정보 업데이트 수행
+
+## 6. 병렬 실행 모델
+
+### 6.1 Run-level 병렬화
+
+고정 크기 `RunExecutor`를 도입한다.
+
+권장 설정 예시:
+
+- `eval.worker.max-concurrent-runs = 2~4`
+- `eval.worker.dispatch-interval-ms = 500~1000`
+
+역할:
+
+- 동시에 여러 run을 병렬 실행
+- 하지만 무제한 실행은 금지
+- 인스턴스 전체의 run-level concurrency를 명시적으로 제어
+
+### 6.2 Case-level 병렬화
+
+run 하나 안에서도 case를 병렬 처리한다.
+
+권장 구조:
+
+- 전역 `CaseExecutor`는 bounded pool
+- 각 run은 `maxConcurrentCasesPerRun` 만큼만 case task를 제출
+- 제출 후 `CompletionService` 또는 유사 구조로 완료된 case를 수집
+
+권장 설정 예시:
+
+- `eval.execution.max-concurrent-cases-per-run = 2~4`
+- `eval.execution.max-active-cases-global = 8~16`
+
+중요:
+
+- run마다 별도 thread pool을 만들지 않는다.
+- 전역 bounded case executor + per-run concurrency gate 구조가 더 안정적이다.
+
+### 6.3 Provider-level 제한
+
+case를 병렬화하면 candidate, baseline, judge 호출이 한 번에 몰린다.
+따라서 provider/model별 concurrency limiter가 필요하다.
+
+권장 정책:
+
+- `OPENAI`, `ANTHROPIC`, `GEMINI`별 permit 제한
+- 필요 시 `provider + role(candidate/judge)` 기준 분리
+- limiter 획득 전에는 외부 API 호출 금지
+
+권장 설정 예시:
+
+- `eval.runner.provider-limits.openai.max-concurrent-calls = 6`
+- `eval.runner.provider-limits.anthropic.max-concurrent-calls = 3`
+- `eval.runner.provider-limits.gemini.max-concurrent-calls = 3`
+
+## 7. 서비스 책임 재구성
+
+### 유지
+
+- `EvalRunService`
+  - enqueue
+  - run 조회
+  - cancel 요청
+  - recovery 진입점
+
+### 분리/추가
+
+- `EvalRunDispatcher`
+  - poll
+  - claim
+  - run executor submit
+
+- `EvalRunExecutionService`
+  - run 시작
+  - case scheduling
+  - finalization
+
+- `EvalCaseExecutionService`
+  - case 1건 처리
+  - candidate/baseline/judge 호출
+  - case 상태 저장
+
+- `EvalProviderConcurrencyLimiter`
+  - provider별 permit 획득/반납
+
+- `EvalRunLeaseService`
+  - heartbeat 갱신
+  - stale claim / stale running 회수
+
+현재의 `EvalExecutionService`는 orchestration/finalization 중심으로 축소하고, case 실행 상세 로직은 별도 서비스로 떼어내는 것이 좋다.
+
+## 8. 트랜잭션과 데이터 정합성
+
+병렬화를 하려면 긴 트랜잭션을 피해야 한다.
+
+원칙:
+
+- run orchestration과 case 실행을 같은 트랜잭션에 묶지 않는다.
+- case 1건은 자체 트랜잭션으로 실행하고 저장한다.
+- run 최종 summary는 모든 case 종료 후 별도 트랜잭션에서 계산한다.
+
+### run 카운터 갱신 방식 변경
+
+현재처럼 `run.onCaseOk()` / `run.onCaseError()`로 run 엔티티 카운터를 직접 올리는 방식은 병렬 실행 시 위험하다.
+
+대안:
+
+- 방법 A: repository 레벨 atomic increment 쿼리 사용
+- 방법 B: case 결과 집계 쿼리를 source of truth로 사용
+
+최적안 기준 권장:
+
+- 진행률 표시는 집계 쿼리 기반으로 계산
+- run 완료 시 summary도 case 결과 집계 기반으로 계산
+- 필요하면 화면 응답용 캐시 필드만 별도 업데이트
+
+## 9. 취소와 복구 정책
+
+### 취소
+
+`cancelRun()` 동작을 두 단계로 나눈다.
+
+- `QUEUED` / `CLAIMED`: 즉시 `CANCELLED`
+- `RUNNING`: `CANCEL_REQUESTED`로 전환
+
+`CANCEL_REQUESTED` 상태에서는:
+
+- 새 case 제출 중단
+- 아직 시작하지 않은 case는 `QUEUED` 유지 또는 `CANCELLED` 처리 정책 결정
+- 이미 진행 중인 provider 호출은 즉시 강제 중단이 안 될 수 있으므로 cooperative cancel 방식 사용
+
+### 복구
+
+startup recovery만으로는 부족하다.
+
+추가 정책:
+
+- `CLAIMED`인데 lease 만료된 run은 `QUEUED`로 복구
+- `RUNNING`인데 heartbeat/lease 만료된 run은 실행 중단으로 판단하고 복구
+- `RUNNING` case는 `QUEUED`로 되돌리고 부분 결과 초기화
+
+## 10. Summary / Release Decision 처리
+
+모든 case가 끝난 뒤에만 run finalization을 수행한다.
+
+finalization 단계:
+
+- case 결과 aggregate 조회
+- `avgOverallScore`, `passRate`, `errorRate`, compare coverage 계산
+- `releaseDecision` 계산
+- performance summary 계산
+- top issues 계산
+- `llmOverallReview` 생성
+- 최종 `COMPLETED` 또는 `FAILED` 저장
+
+주의:
+
+- finalization은 정확히 한 번만 실행되어야 한다.
+- 동일 run에 대해 중복 finalization이 발생하지 않도록 terminal transition 보호가 필요하다.
+
+## 11. 설정 변경안
+
+기존:
+
+- `eval.worker.poll-interval-ms`
+- `eval.worker.batch-size`
+
+권장 변경:
+
+- `eval.worker.dispatch-interval-ms`
+- `eval.worker.max-concurrent-runs`
+- `eval.worker.claim-batch-size`
+- `eval.execution.max-concurrent-cases-per-run`
+- `eval.execution.max-active-cases-global`
+- `eval.execution.claim-lease-seconds`
+- `eval.execution.run-lease-seconds`
+- `eval.execution.heartbeat-interval-seconds`
+- `eval.runner.provider-limits.*.max-concurrent-calls`
+
+기존 `run-timeout-minutes`, `request-timeout-ms`, `same-provider-retry-*`는 유지한다.
+
+## 12. 코드 변경 범위
+
+### Domain / Enum
+
+- `EvalRunStatus`
+- `EvalRun`
+
+### Repository
+
+- `EvalRunRepository`
+- 필요 시 progress aggregate query repository 추가
+
+### Service
+
+- `EvalRunService`
+- `EvalExecutionService`
+- 신규 `EvalRunDispatcher`
+- 신규 `EvalRunExecutionService`
+- 신규 `EvalCaseExecutionService`
+- 신규 `EvalProviderConcurrencyLimiter`
+- 신규 `EvalRunLeaseService`
+
+### Config
+
+- `EvalProperties`
+- executor / scheduler bean 설정
+
+### DB / Migration
+
+- `eval_runs` 컬럼 추가
+- 상태값 확장
+- queue/lease 조회용 인덱스 추가
+
+### Tests
+
+- worker/dispatcher 동작 테스트
+- claim 중복 방지 테스트
+- case 병렬 처리 테스트
+- cancel / recovery 테스트
+- provider limiter 테스트
+- summary 정확성 테스트
+
+## 13. 구현 단계
+
+### Phase 1. 상태/스키마 정비
+
+- `CLAIMED`, `CANCEL_REQUESTED` 상태 추가
+- lease/heartbeat 관련 컬럼 추가
+- `startedAt` 의미를 실제 compute start로 재정의
+
+### Phase 2. Dispatcher + Run Executor
+
+- 현재 `EvalWorker`를 dispatcher 역할로 축소
+- run executor 도입
+- 안전한 claim 로직 구현
+
+### Phase 3. Case 실행 분리
+
+- `processCase()`를 별도 서비스로 추출
+- case 1건 단위 트랜잭션 분리
+
+### Phase 4. Case-level 병렬화
+
+- 전역 case executor 도입
+- per-run concurrency gate 추가
+- case futures 수집 구조 도입
+
+### Phase 5. Provider limiter
+
+- provider/model별 semaphore 또는 limiter 추가
+- 설정값 외부화
+
+### Phase 6. 취소/복구/heartbeat
+
+- `CANCEL_REQUESTED` 처리
+- stale lease recovery
+- heartbeat 주기 갱신
+
+### Phase 7. 메트릭/가시성
+
+- queue wait
+- claim wait
+- actual run duration
+- active runs
+- active cases
+- provider permit usage
+- judge retry count
+
+### Phase 8. 재벤치마크
+
+- 단건 baseline 재측정
+- 3건, 5건, 10건 enqueue burst 재측정
+- provider 429/error rate 확인
+- 비용 증가 추이 확인
+- 기존 기준선과 아래 항목을 직접 비교
+- 단건 평균 완료 시간: `32.988s`
+- 3건 enqueue 후 평균 완료 시간: `62.488s`
+- 3건 enqueue 후 최대 완료 시간: `96.569s`
+- queue 대기 평균: `22.331s`
+- API 응답 평균: `30.3ms`
+- 동일한 시나리오 조건을 유지한 상태에서 개선 폭을 기록
+
+## 14. 검증 항목
+
+기능 검증:
+
+- 동시에 여러 run이 실제 병렬 실행된다
+- 동일 run이 중복 claim되지 않는다
+- `startedAt`은 실제 실행 시작 시각이다
+- `COMPARE_ACTIVE`에서도 compare summary가 정상 저장된다
+- cancel 요청 시 새 case가 더 이상 시작되지 않는다
+- 앱 재시작 후 stale claim/run이 복구된다
+
+성능 검증:
+
+- 단건 평균 완료 시간이 기존 `32.988s` 대비 악화되지 않거나 허용 범위 내로 유지된다
+- 3건 burst에서 평균 완료 시간이 기존 `62.488s` 대비 유의미하게 감소한다
+- 3건 burst에서 최대 완료 시간이 기존 `96.569s` 대비 유의미하게 감소한다
+- queue wait 평균이 기존 `22.331s` 대비 유의미하게 감소한다
+- API 응답 평균은 기존 `30.3ms` 수준을 크게 해치지 않는다
+- queue wait 비중이 줄어든다
+- provider 429 비율이 허용 범위 안에 있다
+- DB/Hikari/thread pool이 포화되지 않는다
+
+## 15. 리스크와 대응
+
+- 리스크: 병렬 case 처리로 provider 429 증가
+  - 대응: provider limiter, same-provider retry, 초기 보수적 concurrency
+
+- 리스크: run 카운터 경합으로 summary 오염
+  - 대응: case 결과 aggregate 기반 계산으로 전환
+
+- 리스크: cancel 직후 일부 in-flight 호출은 끝까지 수행될 수 있음
+  - 대응: cooperative cancel 정책을 명시하고 UI에도 반영
+
+- 리스크: lease/heartbeat 버그로 run 중복 실행
+  - 대응: claim/finalization/cancel race 조건 테스트 강화
+
+- 리스크: 병렬화 후 비용이 짧은 시간에 급증
+  - 대응: global/provider concurrency 상한, 운영 기본값 보수 설정
+
+## 16. 권장 기본값 초안
+
+운영 첫 배포 기준 보수적 시작값:
+
+- `max-concurrent-runs = 2`
+- `max-concurrent-cases-per-run = 2`
+- `max-active-cases-global = 6`
+- `openai.max-concurrent-calls = 4`
+- `dispatch-interval-ms = 1000`
+
+초기에는 낮은 값으로 배포하고, 재벤치마크 후 단계적으로 올리는 것이 안전하다.
+
+## 17. 결론
+
+최적안의 핵심은 "무제한 병렬화"가 아니라 "정확한 상태 모델과 제한된 병렬 실행 구조"다.
+
+따라서 구현 방향은 아래 한 줄로 정리된다.
+
+- 큐는 유지하고, `CLAIMED -> RUNNING`을 분리한 뒤, run-level / case-level / provider-level 병렬성을 각각 통제 가능한 구조로 재설계한다.
+
+## 18. 구현 및 재측정 결과 (2026-03-18)
+
+### 구현 반영 상태
+
+- `EvalRunStatus`에 `CLAIMED`, `CANCEL_REQUESTED`를 추가했다.
+- `EvalWorker`는 queued run을 claim하고 executor에 제출하는 dispatcher 역할로 축소했다.
+- run-level bounded executor와 case-level bounded executor를 도입했다.
+- provider별 semaphore 기반 동시성 제한을 추가했다.
+- `cancelRun()`은 `QUEUED/CLAIMED`에서는 즉시 `CANCELLED`, 실행 중에는 `CANCEL_REQUESTED`로 처리하도록 정리했다.
+- lease/heartbeat/recovery를 위한 `eval_runs` 컬럼과 인덱스를 `V32__eval_parallel_execution_state.sql`로 추가했다.
+
+### 적용 확인
+
+- Flyway `V32` migration 적용 완료
+- 스모크 E2E 확인 완료
+  - `run 216`: 정상 생성 후 `COMPLETED`
+  - `run 217`: 생성 직후 취소 후 `CANCELLED`
+
+### 재측정 결과
+
+단건 baseline:
+
+- 평균 완료 시간: `22.418s`
+- 최대 완료 시간: `23.881s`
+- 평균 queue 대기: `1.329s`
+- 평균 API 응답: `84.5ms`
+- 평균 비용: `$0.004990 / run`
+
+3건 enqueue burst:
+
+- 평균 완료 시간: `44.115s`
+- 최대 완료 시간: `56.666s`
+- 평균 queue 대기: `12.780s`
+- 평균 API 응답: `43.3ms`
+- 평균 비용: `$0.005014 / run`
+
+기준선 대비:
+
+- 단건 평균 완료 시간: `32.988s -> 22.418s` (`-32.0%`)
+- 3건 burst 평균 완료 시간: `62.488s -> 44.115s` (`-29.4%`)
+- 3건 burst 최대 완료 시간: `96.569s -> 56.666s` (`-41.3%`)
+- 평균 queue 대기: `22.331s -> 12.780s` (`-42.8%`)
+
+### 남은 병목
+
+- 현재 운영 기본값이 `max-concurrent-runs = 2`라서, 3건 burst 시 세 번째 run은 여전히 대기한다.
+- 실제 측정에서도 세 번째 run(`223`)은 `Created -> Started = 35.821s`가 나왔고, 이 값이 현재 최대 완료 시간의 주된 원인이다.
+
+### 다음 튜닝 순서
+
+- `max-concurrent-runs`를 올릴지 검토
+- `max-concurrent-cases-per-run` 상향 시 provider 429 / 비용 추이 재측정
+- 동일 시나리오로 `5건`, `10건` burst 추가 측정

--- a/docs/prompt-eval-parallelization-plan.md
+++ b/docs/prompt-eval-parallelization-plan.md
@@ -146,7 +146,7 @@ HTTP createRun
 
 권장 설정 예시:
 
-- `eval.worker.max-concurrent-runs = 2~4`
+- `eval.worker.max-concurrent-runs = 3~4`
 - `eval.worker.dispatch-interval-ms = 500~1000`
 
 역할:
@@ -463,13 +463,13 @@ finalization 단계:
 
 운영 첫 배포 기준 보수적 시작값:
 
-- `max-concurrent-runs = 2`
+- `max-concurrent-runs = 3`
 - `max-concurrent-cases-per-run = 2`
 - `max-active-cases-global = 6`
 - `openai.max-concurrent-calls = 4`
 - `dispatch-interval-ms = 1000`
 
-초기에는 낮은 값으로 배포하고, 재벤치마크 후 단계적으로 올리는 것이 안전하다.
+`2 -> 3 -> 4` 재벤치마크 결과, 현재 limiter 조합에서는 `3`이 가장 균형이 좋았다.
 
 ## 17. 결론
 
@@ -524,11 +524,30 @@ finalization 단계:
 
 ### 남은 병목
 
-- 현재 운영 기본값이 `max-concurrent-runs = 2`라서, 3건 burst 시 세 번째 run은 여전히 대기한다.
-- 실제 측정에서도 세 번째 run(`223`)은 `Created -> Started = 35.821s`가 나왔고, 이 값이 현재 최대 완료 시간의 주된 원인이다.
+- 초기 재측정 기준 `max-concurrent-runs = 2`에서는 3건 burst 시 세 번째 run 대기가 컸다.
+- 후속 튜닝 결과 `max-concurrent-runs = 3`이 현재 limiter 조합에서 가장 안정적이었다.
+- 이제 주요 병목은 run 슬롯보다 `max-active-cases-global = 6`과 `openai-max-concurrent-calls = 4` 쪽으로 이동했다.
+
+### 후속 튜닝 결과 (`max-concurrent-runs` 3 vs 4)
+
+3건 burst:
+
+- `max=3`: 평균 queue `2.738s`, 평균 완료 `21.520s`, 최대 완료 `22.852s`
+- `max=4`: 평균 queue `2.329s`, 평균 완료 `22.053s`, 최대 완료 `23.489s`
+
+5건 burst:
+
+- `max=3`: 평균 queue `8.178s`, 평균 완료 `23.532s`, 최대 완료 `32.126s`
+- `max=4`: 평균 queue `6.143s`, 평균 완료 `26.016s`, 최대 완료 `35.459s`
+
+판단:
+
+- `2 -> 3`은 큰 개선이다.
+- `3 -> 4`는 queue wait 일부만 줄이고 completion은 악화됐다.
+- 따라서 현재 기본 운영값은 `max-concurrent-runs = 3`으로 두는 것이 적절하다.
 
 ### 다음 튜닝 순서
 
-- `max-concurrent-runs`를 올릴지 검토
 - `max-concurrent-cases-per-run` 상향 시 provider 429 / 비용 추이 재측정
-- 동일 시나리오로 `5건`, `10건` burst 추가 측정
+- `max-active-cases-global`과 provider permit 동시 상향 여부 검토
+- 동일 시나리오로 `10건` burst 추가 측정

--- a/docs/prompt-eval-parallelization-plan.md
+++ b/docs/prompt-eval-parallelization-plan.md
@@ -464,12 +464,12 @@ finalization 단계:
 운영 첫 배포 기준 보수적 시작값:
 
 - `max-concurrent-runs = 3`
-- `max-concurrent-cases-per-run = 2`
-- `max-active-cases-global = 6`
-- `openai.max-concurrent-calls = 4`
+- `max-concurrent-cases-per-run = 3`
+- `max-active-cases-global = 9`
+- `openai.max-concurrent-calls = 6`
 - `dispatch-interval-ms = 1000`
 
-`2 -> 3 -> 4` 재벤치마크 결과, 현재 limiter 조합에서는 `3`이 가장 균형이 좋았다.
+`2 -> 3 -> 4` 재벤치마크 후 run 기본값을 `3`으로 올렸고, 추가 `10건 burst` 실험에서 case/global/provider limiter를 함께 올린 조합이 더 좋은 completion을 보였다.
 
 ## 17. 결론
 
@@ -526,7 +526,8 @@ finalization 단계:
 
 - 초기 재측정 기준 `max-concurrent-runs = 2`에서는 3건 burst 시 세 번째 run 대기가 컸다.
 - 후속 튜닝 결과 `max-concurrent-runs = 3`이 현재 limiter 조합에서 가장 안정적이었다.
-- 이제 주요 병목은 run 슬롯보다 `max-active-cases-global = 6`과 `openai-max-concurrent-calls = 4` 쪽으로 이동했다.
+- `10건 burst` 기준으로는 `max-active-cases-global = 6`과 `openai-max-concurrent-calls = 4`가 실제 병목이었다.
+- 이를 `case=3`, `global=9`, `openai=6`으로 올렸을 때 평균/최대 completion이 일관되게 개선됐다.
 
 ### 후속 튜닝 결과 (`max-concurrent-runs` 3 vs 4)
 
@@ -548,6 +549,20 @@ finalization 단계:
 
 ### 다음 튜닝 순서
 
-- `max-concurrent-cases-per-run` 상향 시 provider 429 / 비용 추이 재측정
-- `max-active-cases-global`과 provider permit 동시 상향 여부 검토
-- 동일 시나리오로 `10건` burst 추가 측정
+10건 burst 추가 결과:
+
+- 기본값(`run=3`, `case=2`, `global=6`, `openai=4`): 평균 queue `27.538s`, 평균 완료 `48.564s`, 최대 완료 `79.854s`
+- 튜닝값 1차(`run=3`, `case=3`, `global=9`, `openai=6`): 평균 queue `17.541s`, 평균 완료 `32.064s`, 최대 완료 `54.004s`
+- 튜닝값 2차(`run=3`, `case=3`, `global=9`, `openai=6`): 평균 queue `18.013s`, 평균 완료 `33.529s`, 최대 완료 `53.414s`
+
+판단:
+
+- 장기 적체 구간에서는 `case/global/provider` 상향이 실효성이 있었다.
+- 2회 반복 측정에서 개선 방향이 동일했고, 두 번 모두 `10/10 COMPLETED`였다.
+- 따라서 현재 권장 운영 기본값은 `run=3`, `case=3`, `global=9`, `openai=6`이다.
+
+### 다음 튜닝 순서
+
+- 동일 조합으로 `20건` burst 재측정
+- OpenAI 429/timeout 증가 여부 확인
+- Hikari pool 사용량과 DB 경합 지표 확인

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
@@ -1,0 +1,97 @@
+package com.llm_ops.demo.eval.config;
+
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class EvalExecutionConfig {
+
+    private final EvalProperties evalProperties;
+    private ExecutorService evalRunExecutor;
+    private ExecutorService evalCaseExecutor;
+
+    public EvalExecutionConfig(EvalProperties evalProperties) {
+        this.evalProperties = evalProperties;
+    }
+
+    @Bean(name = "evalRunExecutor")
+    public ThreadPoolExecutor evalRunExecutor() {
+        int maxConcurrentRuns = Math.max(1, evalProperties.getWorker().getMaxConcurrentRuns());
+        AtomicInteger sequence = new AtomicInteger(1);
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("eval-run-" + sequence.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
+        this.evalRunExecutor = new ThreadPoolExecutor(
+                maxConcurrentRuns,
+                maxConcurrentRuns,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new SynchronousQueue<>(),
+                threadFactory,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        return (ThreadPoolExecutor) this.evalRunExecutor;
+    }
+
+    @Bean(name = "evalCaseExecutor")
+    public ThreadPoolExecutor evalCaseExecutor() {
+        int maxActiveCases = Math.max(1, evalProperties.getExecution().getMaxActiveCasesGlobal());
+        int queueCapacity = Math.max(maxActiveCases, evalProperties.getExecution().getMaxCaseQueueCapacity());
+        AtomicInteger sequence = new AtomicInteger(1);
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("eval-case-" + sequence.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
+        BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(queueCapacity);
+        this.evalCaseExecutor = new ThreadPoolExecutor(
+                maxActiveCases,
+                maxActiveCases,
+                0L,
+                TimeUnit.MILLISECONDS,
+                queue,
+                threadFactory,
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+        return (ThreadPoolExecutor) this.evalCaseExecutor;
+    }
+
+    @PreDestroy
+    public void shutdownExecutors() {
+        shutdownExecutor(evalCaseExecutor, "evalCaseExecutor");
+        shutdownExecutor(evalRunExecutor, "evalRunExecutor");
+    }
+
+    private void shutdownExecutor(ExecutorService executorService, String name) {
+        if (executorService == null) {
+            return;
+        }
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    log.warn("{} did not terminate within timeout", name);
+                }
+            }
+        } catch (InterruptedException exception) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
@@ -66,7 +66,7 @@ public class EvalExecutionConfig {
                 TimeUnit.MILLISECONDS,
                 queue,
                 threadFactory,
-                new ThreadPoolExecutor.CallerRunsPolicy()
+                new ThreadPoolExecutor.AbortPolicy()
         );
         return (ThreadPoolExecutor) this.evalCaseExecutor;
     }

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
@@ -18,8 +18,8 @@ import org.springframework.context.annotation.Configuration;
 public class EvalExecutionConfig {
 
     private final EvalProperties evalProperties;
-    private ExecutorService evalRunExecutor;
-    private ExecutorService evalCaseExecutor;
+    private ThreadPoolExecutor evalRunExecutor;
+    private ThreadPoolExecutor evalCaseExecutor;
 
     public EvalExecutionConfig(EvalProperties evalProperties) {
         this.evalProperties = evalProperties;
@@ -44,7 +44,7 @@ public class EvalExecutionConfig {
                 threadFactory,
                 new ThreadPoolExecutor.AbortPolicy()
         );
-        return (ThreadPoolExecutor) this.evalRunExecutor;
+        return this.evalRunExecutor;
     }
 
     @Bean(name = "evalCaseExecutor")
@@ -68,7 +68,7 @@ public class EvalExecutionConfig {
                 threadFactory,
                 new ThreadPoolExecutor.AbortPolicy()
         );
-        return (ThreadPoolExecutor) this.evalCaseExecutor;
+        return this.evalCaseExecutor;
     }
 
     @PreDestroy

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
@@ -73,8 +73,8 @@ public class EvalExecutionConfig {
 
     @PreDestroy
     public void shutdownExecutors() {
-        shutdownExecutor(evalCaseExecutor, "evalCaseExecutor");
         shutdownExecutor(evalRunExecutor, "evalRunExecutor");
+        shutdownExecutor(evalCaseExecutor, "evalCaseExecutor");
     }
 
     private void shutdownExecutor(ExecutorService executorService, String name) {

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
@@ -104,8 +104,8 @@ public class EvalProperties {
     @Getter
     @Setter
     public static class Execution {
-        private int maxConcurrentCasesPerRun = 2;
-        private int maxActiveCasesGlobal = 6;
+        private int maxConcurrentCasesPerRun = 3;
+        private int maxActiveCasesGlobal = 9;
         private int maxCaseQueueCapacity = 24;
     }
 
@@ -121,7 +121,7 @@ public class EvalProperties {
     @Getter
     @Setter
     public static class ProviderLimits {
-        private int openaiMaxConcurrentCalls = 4;
+        private int openaiMaxConcurrentCalls = 6;
         private int anthropicMaxConcurrentCalls = 3;
         private int geminiMaxConcurrentCalls = 3;
     }

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
@@ -96,7 +96,7 @@ public class EvalProperties {
         private long pollIntervalMs = 3000L;
         private int batchSize = 3;
         private int maxConcurrentRuns = 3;
-        private int claimBatchSize = 2;
+        private int claimBatchSize = 3;
         private long claimLeaseSeconds = 30L;
         private long runLeaseSeconds = 900L;
     }

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
@@ -95,7 +95,7 @@ public class EvalProperties {
     public static class Worker {
         private long pollIntervalMs = 3000L;
         private int batchSize = 3;
-        private int maxConcurrentRuns = 2;
+        private int maxConcurrentRuns = 3;
         private int claimBatchSize = 2;
         private long claimLeaseSeconds = 30L;
         private long runLeaseSeconds = 900L;

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
@@ -15,6 +15,7 @@ public class EvalProperties {
     private long runTimeoutMinutes = 30L;
     private Judge judge = new Judge();
     private Worker worker = new Worker();
+    private Execution execution = new Execution();
     private Runner runner = new Runner();
 
     public long getRunTimeoutMinutes() {
@@ -36,6 +37,10 @@ public class EvalProperties {
 
     public Runner getRunner() {
         return runner;
+    }
+
+    public Execution getExecution() {
+        return execution;
     }
 
     public static class Judge {
@@ -90,6 +95,18 @@ public class EvalProperties {
     public static class Worker {
         private long pollIntervalMs = 3000L;
         private int batchSize = 3;
+        private int maxConcurrentRuns = 2;
+        private int claimBatchSize = 2;
+        private long claimLeaseSeconds = 30L;
+        private long runLeaseSeconds = 900L;
+    }
+
+    @Getter
+    @Setter
+    public static class Execution {
+        private int maxConcurrentCasesPerRun = 2;
+        private int maxActiveCasesGlobal = 6;
+        private int maxCaseQueueCapacity = 24;
     }
 
     @Getter
@@ -98,5 +115,14 @@ public class EvalProperties {
         private long requestTimeoutMs = 20000L;
         private int sameProviderRetryMaxAttempts = 1;
         private long sameProviderRetryBackoffMs = 200L;
+        private ProviderLimits providerLimits = new ProviderLimits();
+    }
+
+    @Getter
+    @Setter
+    public static class ProviderLimits {
+        private int openaiMaxConcurrentCalls = 4;
+        private int anthropicMaxConcurrentCalls = 3;
+        private int geminiMaxConcurrentCalls = 3;
     }
 }

--- a/src/main/java/com/llm_ops/demo/eval/domain/EvalCaseResult.java
+++ b/src/main/java/com/llm_ops/demo/eval/domain/EvalCaseResult.java
@@ -254,6 +254,13 @@ public class EvalCaseResult {
         this.completedAt = LocalDateTime.now();
     }
 
+    public void markSkipped(String errorCode, String errorMessage) {
+        this.status = EvalCaseStatus.SKIPPED.name();
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.completedAt = LocalDateTime.now();
+    }
+
     public void resetToQueuedForRecovery() {
         if (!EvalCaseStatus.RUNNING.name().equals(this.status)) {
             return;

--- a/src/main/java/com/llm_ops/demo/eval/domain/EvalRun.java
+++ b/src/main/java/com/llm_ops/demo/eval/domain/EvalRun.java
@@ -100,11 +100,26 @@ public class EvalRun {
     @Column(name = "started_at")
     private LocalDateTime startedAt;
 
+    @Column(name = "claimed_at")
+    private LocalDateTime claimedAt;
+
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
     @Column(name = "timeout_at")
     private LocalDateTime timeoutAt;
+
+    @Column(name = "lease_owner", length = 120)
+    private String leaseOwner;
+
+    @Column(name = "lease_expires_at")
+    private LocalDateTime leaseExpiresAt;
+
+    @Column(name = "last_heartbeat_at")
+    private LocalDateTime lastHeartbeatAt;
+
+    @Column(name = "cancel_requested_at")
+    private LocalDateTime cancelRequestedAt;
 
     @Column(name = "fail_reason_code", length = 50)
     private String failReasonCode;
@@ -174,27 +189,87 @@ public class EvalRun {
         return RubricTemplateCode.valueOf(rubricTemplateCode);
     }
 
-    public void markRunning() {
+    public LocalDateTime getClaimedAt() {
+        return claimedAt;
+    }
+
+    public String getLeaseOwner() {
+        return leaseOwner;
+    }
+
+    public LocalDateTime getLeaseExpiresAt() {
+        return leaseExpiresAt;
+    }
+
+    public LocalDateTime getLastHeartbeatAt() {
+        return lastHeartbeatAt;
+    }
+
+    public LocalDateTime getCancelRequestedAt() {
+        return cancelRequestedAt;
+    }
+
+    public void markClaimed(String leaseOwner, Duration leaseDuration) {
         if (status() == EvalRunStatus.QUEUED) {
+            LocalDateTime now = LocalDateTime.now();
+            status = EvalRunStatus.CLAIMED.name();
+            claimedAt = now;
+            this.leaseOwner = leaseOwner;
+            leaseExpiresAt = leaseDuration != null ? now.plus(leaseDuration) : null;
+            lastHeartbeatAt = now;
+        }
+    }
+
+    public void markRunning() {
+        markRunningWithTimeout(null, null);
+    }
+
+    public void markRunningWithTimeout(Duration maxDuration, Duration leaseDuration) {
+        EvalRunStatus currentStatus = status();
+        if (currentStatus == EvalRunStatus.CLAIMED || currentStatus == EvalRunStatus.QUEUED) {
+            LocalDateTime now = LocalDateTime.now();
             status = EvalRunStatus.RUNNING.name();
-            startedAt = LocalDateTime.now();
+            startedAt = now;
+            timeoutAt = maxDuration != null ? now.plus(maxDuration) : null;
+            lastHeartbeatAt = now;
+            leaseExpiresAt = leaseDuration != null ? now.plus(leaseDuration) : leaseExpiresAt;
         }
     }
 
     public void markRunningWithTimeout(Duration maxDuration) {
-        if (status() == EvalRunStatus.QUEUED) {
-            status = EvalRunStatus.RUNNING.name();
-            startedAt = LocalDateTime.now();
-            timeoutAt = startedAt.plus(maxDuration);
-        }
+        markRunningWithTimeout(maxDuration, null);
     }
 
-    public boolean ensureTimeoutIfMissing(Duration maxDuration) {
-        if (status() == EvalRunStatus.RUNNING && startedAt != null && timeoutAt == null) {
+    public boolean ensureTimeoutIfMissing(Duration maxDuration, Duration leaseDuration) {
+        if ((status() == EvalRunStatus.RUNNING || status() == EvalRunStatus.CANCEL_REQUESTED)
+                && startedAt != null
+                && timeoutAt == null) {
+            LocalDateTime now = LocalDateTime.now();
             timeoutAt = startedAt.plus(maxDuration);
+            lastHeartbeatAt = now;
+            if (leaseDuration != null) {
+                leaseExpiresAt = now.plus(leaseDuration);
+            }
             return true;
         }
         return false;
+    }
+
+    public boolean ensureTimeoutIfMissing(Duration maxDuration) {
+        return ensureTimeoutIfMissing(maxDuration, null);
+    }
+
+    public void heartbeat(Duration leaseDuration) {
+        LocalDateTime now = LocalDateTime.now();
+        lastHeartbeatAt = now;
+        if (leaseDuration != null) {
+            leaseExpiresAt = now.plus(leaseDuration);
+        }
+    }
+
+    public boolean isCancellationRequested() {
+        EvalRunStatus currentStatus = status();
+        return currentStatus == EvalRunStatus.CANCEL_REQUESTED || currentStatus == EvalRunStatus.CANCELLED;
     }
 
     public boolean isTimedOut() {
@@ -209,14 +284,29 @@ public class EvalRun {
         this.failReasonCode = reasonCode;
         this.failReason = reasonMessage;
         this.completedAt = LocalDateTime.now();
+        clearExecutionLease();
     }
 
 
-    public void markCancelled() {
-        if (status() == EvalRunStatus.QUEUED || status() == EvalRunStatus.RUNNING) {
+    public void requestCancel() {
+        EvalRunStatus currentStatus = status();
+        if (currentStatus == EvalRunStatus.QUEUED || currentStatus == EvalRunStatus.CLAIMED) {
             status = EvalRunStatus.CANCELLED.name();
             completedAt = LocalDateTime.now();
+            failReasonCode = "RUN_CANCELLED";
+            failReason = "사용자 요청으로 취소되었습니다.";
+            clearExecutionLease();
+            return;
         }
+
+        if (currentStatus == EvalRunStatus.RUNNING) {
+            status = EvalRunStatus.CANCEL_REQUESTED.name();
+            cancelRequestedAt = LocalDateTime.now();
+        }
+    }
+
+    public void markCancelled() {
+        requestCancel();
     }
 
     public void onCaseOk(boolean pass) {
@@ -238,6 +328,7 @@ public class EvalRun {
         this.costJson = costJson;
         this.status = EvalRunStatus.COMPLETED.name();
         this.completedAt = LocalDateTime.now();
+        clearExecutionLease();
     }
 
     public void fail(Map<String, Object> summaryJson, Map<String, Object> costJson) {
@@ -245,12 +336,42 @@ public class EvalRun {
         this.costJson = costJson;
         this.status = EvalRunStatus.FAILED.name();
         this.completedAt = LocalDateTime.now();
+        clearExecutionLease();
+    }
+
+    public void cancel(Map<String, Object> summaryJson, Map<String, Object> costJson) {
+        this.summaryJson = summaryJson;
+        this.costJson = costJson;
+        this.status = EvalRunStatus.CANCELLED.name();
+        this.completedAt = LocalDateTime.now();
+        this.failReasonCode = "RUN_CANCELLED";
+        this.failReason = "사용자 요청으로 취소되었습니다.";
+        clearExecutionLease();
+    }
+
+    public void syncCaseCounts(int processedCases, int passedCases, int failedCases, int errorCases) {
+        this.processedCases = processedCases;
+        this.passedCases = passedCases;
+        this.failedCases = failedCases;
+        this.errorCases = errorCases;
     }
 
     public void resetToQueued() {
         this.status = EvalRunStatus.QUEUED.name();
+        this.claimedAt = null;
         this.startedAt = null;
         this.timeoutAt = null;
+        this.completedAt = null;
+        this.failReasonCode = null;
+        this.failReason = null;
+        this.cancelRequestedAt = null;
+        clearExecutionLease();
+    }
+
+    private void clearExecutionLease() {
+        leaseOwner = null;
+        leaseExpiresAt = null;
+        lastHeartbeatAt = null;
     }
 
 }

--- a/src/main/java/com/llm_ops/demo/eval/domain/EvalRunStatus.java
+++ b/src/main/java/com/llm_ops/demo/eval/domain/EvalRunStatus.java
@@ -2,7 +2,9 @@ package com.llm_ops.demo.eval.domain;
 
 public enum EvalRunStatus {
     QUEUED,
+    CLAIMED,
     RUNNING,
+    CANCEL_REQUESTED,
     COMPLETED,
     FAILED,
     CANCELLED

--- a/src/main/java/com/llm_ops/demo/eval/repository/EvalCaseResultRepository.java
+++ b/src/main/java/com/llm_ops/demo/eval/repository/EvalCaseResultRepository.java
@@ -82,6 +82,16 @@ public interface EvalCaseResultRepository extends JpaRepository<EvalCaseResult, 
     @EntityGraph(attributePaths = {"evalRun", "evalRun.prompt", "evalRun.promptVersion", "testCase"})
     Optional<EvalCaseResult> findByIdAndEvalRunId(Long id, Long evalRunId);
 
+    @EntityGraph(attributePaths = {
+            "evalRun",
+            "evalRun.prompt",
+            "evalRun.prompt.workspace",
+            "evalRun.prompt.workspace.organization",
+            "evalRun.promptVersion",
+            "testCase"
+    })
+    Optional<EvalCaseResult> findById(Long id);
+
     Optional<PassProjection> findPassProjectionByIdAndEvalRunId(Long id, Long evalRunId);
 
     @EntityGraph(attributePaths = {"evalRun", "evalRun.prompt", "evalRun.promptVersion", "testCase"})

--- a/src/main/java/com/llm_ops/demo/eval/repository/EvalRunRepository.java
+++ b/src/main/java/com/llm_ops/demo/eval/repository/EvalRunRepository.java
@@ -56,7 +56,9 @@ public interface EvalRunRepository extends JpaRepository<EvalRun, Long> {
             WHERE r.status IN :statuses
               AND (
                     (r.status = 'CLAIMED' AND r.leaseExpiresAt < :cutoffTime)
-                 OR (r.status IN ('RUNNING', 'CANCEL_REQUESTED') AND r.startedAt < :runTimeoutCutoff)
+                 OR (r.status = 'RUNNING' AND r.startedAt < :runTimeoutCutoff)
+                 OR (r.status = 'CANCEL_REQUESTED'
+                     AND (r.leaseExpiresAt < :cutoffTime OR r.startedAt < :runTimeoutCutoff))
               )
             ORDER BY r.createdAt ASC
             """)

--- a/src/main/java/com/llm_ops/demo/eval/repository/EvalRunRepository.java
+++ b/src/main/java/com/llm_ops/demo/eval/repository/EvalRunRepository.java
@@ -2,6 +2,7 @@ package com.llm_ops.demo.eval.repository;
 
 import com.llm_ops.demo.eval.domain.EvalRun;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import jakarta.persistence.LockModeType;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,36 +25,68 @@ public interface EvalRunRepository extends JpaRepository<EvalRun, Long> {
     @EntityGraph(attributePaths = {"prompt", "prompt.workspace", "prompt.workspace.organization", "promptVersion", "dataset"})
     List<EvalRun> findTop10ByStatusOrderByCreatedAtAsc(String status);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-            SELECT r
-            FROM EvalRun r
-            WHERE r.status = :status
-            ORDER BY r.createdAt ASC
-            """)
-    List<EvalRun> findQueuedRunsForUpdate(
+    @Query(
+            value = """
+                    SELECT id
+                    FROM eval_runs
+                    WHERE status = :status
+                    ORDER BY created_at ASC
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT :limit
+                    """,
+            nativeQuery = true
+    )
+    List<Long> findQueuedRunIdsForClaim(
             @Param("status") String status,
-            Pageable pageable
+            @Param("limit") int limit
     );
 
     @EntityGraph(attributePaths = {"prompt", "prompt.workspace", "prompt.workspace.organization", "promptVersion", "dataset"})
     Optional<EvalRun> findById(Long id);
 
-    long countByStatus(String status);
+    @EntityGraph(attributePaths = {"prompt", "prompt.workspace", "prompt.workspace.organization", "promptVersion", "dataset"})
+    List<EvalRun> findByIdInOrderByCreatedAtAsc(Collection<Long> ids);
 
+    long countByStatus(String status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
             SELECT r
             FROM EvalRun r
-            WHERE r.status = :status
-              AND r.startedAt < :cutoffTime
+            WHERE r.status IN :statuses
+              AND (
+                    (r.status = 'CLAIMED' AND r.leaseExpiresAt < :cutoffTime)
+                 OR (r.status IN ('RUNNING', 'CANCEL_REQUESTED') AND r.startedAt < :runTimeoutCutoff)
+              )
             ORDER BY r.createdAt ASC
             """)
-    List<EvalRun> findStuckRunsForUpdate(
-            @Param("status") String status,
+    List<EvalRun> findRecoverableRunsForUpdate(
+            @Param("statuses") List<String> statuses,
             @Param("cutoffTime") LocalDateTime cutoffTime,
+            @Param("runTimeoutCutoff") LocalDateTime runTimeoutCutoff,
             Pageable pageable
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE EvalRun r
+            SET r.processedCases = r.processedCases + 1,
+                r.passedCases = r.passedCases + :passedIncrement,
+                r.failedCases = r.failedCases + :failedIncrement,
+                r.errorCases = r.errorCases + :errorIncrement,
+                r.lastHeartbeatAt = :heartbeatAt,
+                r.leaseExpiresAt = :leaseExpiresAt
+            WHERE r.id = :runId
+              AND r.status IN :statuses
+            """)
+    int incrementProgress(
+            @Param("runId") Long runId,
+            @Param("passedIncrement") int passedIncrement,
+            @Param("failedIncrement") int failedIncrement,
+            @Param("errorIncrement") int errorIncrement,
+            @Param("heartbeatAt") LocalDateTime heartbeatAt,
+            @Param("leaseExpiresAt") LocalDateTime leaseExpiresAt,
+            @Param("statuses") List<String> statuses
     );
 
 }

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalCaseExecutionService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalCaseExecutionService.java
@@ -1,0 +1,374 @@
+package com.llm_ops.demo.eval.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.llm_ops.demo.eval.domain.EvalCaseResult;
+import com.llm_ops.demo.eval.domain.EvalCaseStatus;
+import com.llm_ops.demo.eval.domain.EvalRun;
+import com.llm_ops.demo.eval.domain.EvalRunStatus;
+import com.llm_ops.demo.eval.domain.EvalTestCase;
+import com.llm_ops.demo.eval.domain.RubricTemplateCode;
+import com.llm_ops.demo.eval.repository.EvalCaseResultRepository;
+import com.llm_ops.demo.eval.repository.EvalRunRepository;
+import com.llm_ops.demo.eval.rubric.ResolvedRubricConfig;
+import com.llm_ops.demo.global.error.BusinessException;
+import com.llm_ops.demo.global.error.ErrorCode;
+import com.llm_ops.demo.prompt.domain.PromptVersion;
+import com.llm_ops.demo.prompt.repository.PromptVersionRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EvalCaseExecutionService {
+
+    private final EvalCaseResultRepository evalCaseResultRepository;
+    private final EvalRunRepository evalRunRepository;
+    private final PromptVersionRepository promptVersionRepository;
+    private final EvalModelRunnerService evalModelRunnerService;
+    private final com.llm_ops.demo.eval.rule.EvalRuleCheckerService evalRuleCheckerService;
+    private final EvalJudgeService evalJudgeService;
+    private final ObjectMapper objectMapper;
+
+    public EvalCaseExecutionService(
+            EvalCaseResultRepository evalCaseResultRepository,
+            EvalRunRepository evalRunRepository,
+            PromptVersionRepository promptVersionRepository,
+            EvalModelRunnerService evalModelRunnerService,
+            com.llm_ops.demo.eval.rule.EvalRuleCheckerService evalRuleCheckerService,
+            EvalJudgeService evalJudgeService,
+            ObjectMapper objectMapper
+    ) {
+        this.evalCaseResultRepository = evalCaseResultRepository;
+        this.evalRunRepository = evalRunRepository;
+        this.promptVersionRepository = promptVersionRepository;
+        this.evalModelRunnerService = evalModelRunnerService;
+        this.evalRuleCheckerService = evalRuleCheckerService;
+        this.evalJudgeService = evalJudgeService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void executeCase(
+            Long runId,
+            Long caseResultId,
+            ResolvedRubricConfig rubric,
+            Long baselineVersionId,
+            Duration runLeaseDuration
+    ) {
+        EvalCaseResult caseResult = evalCaseResultRepository.findById(caseResultId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "평가 케이스를 찾을 수 없습니다."));
+        EvalRun run = caseResult.getEvalRun();
+
+        if (!run.getId().equals(runId)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "runId와 caseResultId가 일치하지 않습니다.");
+        }
+
+        if (run.status() == EvalRunStatus.CANCEL_REQUESTED || run.status() == EvalRunStatus.CANCELLED) {
+            if (caseResult.status() == EvalCaseStatus.QUEUED) {
+                caseResult.markSkipped("RUN_CANCELLED", "실행 중 취소되어 시작되지 않은 케이스입니다.");
+                evalCaseResultRepository.save(caseResult);
+            }
+            return;
+        }
+        if (caseResult.status() != EvalCaseStatus.QUEUED) {
+            return;
+        }
+
+        caseResult.markRunning();
+        evalCaseResultRepository.save(caseResult);
+
+        try {
+            EvalTestCase testCase = caseResult.getTestCase();
+            PromptVersion candidateVersion = run.getPromptVersion();
+            PromptVersion baselineVersion = baselineVersionId != null
+                    ? promptVersionRepository.findById(baselineVersionId).orElse(null)
+                    : null;
+
+            Long organizationId = run.getPrompt().getWorkspace().getOrganization().getId();
+            String candidatePrompt = buildFinalPrompt(candidateVersion, testCase);
+            EvalModelRunnerService.ModelExecution candidateExecution = evalModelRunnerService.run(
+                    organizationId,
+                    candidateVersion.getProvider(),
+                    candidateVersion.getModel(),
+                    candidatePrompt,
+                    readTemperature(candidateVersion.getModelConfig()),
+                    resolveMaxOutputTokens(candidateVersion.getProvider(), candidateVersion.getModelConfig())
+            );
+            RubricTemplateCode rubricTemplateCode = run.rubricTemplateCode();
+
+            String baselineOutput = null;
+            Map<String, Object> baselineMeta = null;
+            Map<String, Object> baselineRuleChecks = null;
+            EvalJudgeService.JudgeResult baselineJudgeResult = null;
+            if (baselineVersion != null) {
+                try {
+                    String baselinePrompt = buildFinalPrompt(baselineVersion, testCase);
+                    EvalModelRunnerService.ModelExecution baselineExecution = evalModelRunnerService.run(
+                            organizationId,
+                            baselineVersion.getProvider(),
+                            baselineVersion.getModel(),
+                            baselinePrompt,
+                            readTemperature(baselineVersion.getModelConfig()),
+                            resolveMaxOutputTokens(baselineVersion.getProvider(), baselineVersion.getModelConfig())
+                    );
+                    baselineOutput = baselineExecution.outputText();
+                    baselineMeta = baselineExecution.meta();
+                    baselineRuleChecks = evalRuleCheckerService.check(
+                            baselineExecution.outputText(),
+                            testCase.getConstraintsJson(),
+                            testCase.getExpectedJson(),
+                            rubricTemplateCode
+                    );
+                    baselineJudgeResult = evalJudgeService.judge(
+                            organizationId,
+                            rubric,
+                            testCase.getInputText(),
+                            testCase.getContextJson(),
+                            testCase.getExpectedJson(),
+                            testCase.getConstraintsJson(),
+                            baselineExecution.outputText(),
+                            baselineRuleChecks,
+                            null
+                    );
+                } catch (Exception baselineException) {
+                    baselineMeta = Map.of(
+                            "error", "BASELINE_EXECUTION_FAILED",
+                            "message", sanitizeMessage(baselineException.getMessage())
+                    );
+                }
+            }
+
+            Map<String, Object> ruleChecks = evalRuleCheckerService.check(
+                    candidateExecution.outputText(),
+                    testCase.getConstraintsJson(),
+                    testCase.getExpectedJson(),
+                    rubricTemplateCode
+            );
+            EvalJudgeService.JudgeResult judgeResult = evalJudgeService.judge(
+                    organizationId,
+                    rubric,
+                    testCase.getInputText(),
+                    testCase.getContextJson(),
+                    testCase.getExpectedJson(),
+                    testCase.getConstraintsJson(),
+                    candidateExecution.outputText(),
+                    ruleChecks,
+                    baselineOutput
+            );
+
+            Map<String, Object> judgeOutput = new LinkedHashMap<>(judgeResult.judgeOutput());
+            Map<String, Object> storedRuleChecks = combineRuleChecks(ruleChecks, baselineRuleChecks);
+            if (baselineJudgeResult != null) {
+                judgeOutput.put("baseline", baselineJudgeResult.judgeOutput());
+                judgeOutput.put("compare", buildCompareSummary(judgeResult, baselineJudgeResult));
+            }
+
+            caseResult.markOk(
+                    candidateExecution.outputText(),
+                    baselineOutput,
+                    candidateExecution.meta(),
+                    baselineMeta,
+                    storedRuleChecks,
+                    judgeOutput,
+                    judgeResult.overallScore(),
+                    judgeResult.pass()
+            );
+            evalCaseResultRepository.save(caseResult);
+            incrementRunProgress(runId, judgeResult.pass() ? 1 : 0, judgeResult.pass() ? 0 : 1, 0, runLeaseDuration);
+        } catch (Exception exception) {
+            caseResult.markError("EVAL_CASE_EXECUTION_ERROR", sanitizeMessage(exception.getMessage()));
+            evalCaseResultRepository.save(caseResult);
+            incrementRunProgress(runId, 0, 0, 1, runLeaseDuration);
+        }
+    }
+
+    private void incrementRunProgress(
+            Long runId,
+            int passedIncrement,
+            int failedIncrement,
+            int errorIncrement,
+            Duration runLeaseDuration
+    ) {
+        LocalDateTime heartbeatAt = LocalDateTime.now();
+        LocalDateTime leaseExpiresAt = runLeaseDuration != null ? heartbeatAt.plus(runLeaseDuration) : null;
+        evalRunRepository.incrementProgress(
+                runId,
+                passedIncrement,
+                failedIncrement,
+                errorIncrement,
+                heartbeatAt,
+                leaseExpiresAt,
+                java.util.List.of(EvalRunStatus.RUNNING.name(), EvalRunStatus.CANCEL_REQUESTED.name())
+        );
+    }
+
+    private Map<String, Object> combineRuleChecks(
+            Map<String, Object> candidateRuleChecks,
+            Map<String, Object> baselineRuleChecks
+    ) {
+        Map<String, Object> candidate = candidateRuleChecks != null
+                ? new LinkedHashMap<>(candidateRuleChecks)
+                : new LinkedHashMap<>();
+        if (baselineRuleChecks == null) {
+            return candidate;
+        }
+
+        Map<String, Object> combined = new LinkedHashMap<>(candidate);
+        combined.put("candidate", candidate);
+        combined.put("baseline", new LinkedHashMap<>(baselineRuleChecks));
+        return combined;
+    }
+
+    private Map<String, Object> buildCompareSummary(
+            EvalJudgeService.JudgeResult candidateJudgeResult,
+            EvalJudgeService.JudgeResult baselineJudgeResult
+    ) {
+        double candidateScore = candidateJudgeResult.overallScore();
+        double baselineScore = baselineJudgeResult.overallScore();
+        boolean candidatePass = candidateJudgeResult.pass();
+        boolean baselinePass = baselineJudgeResult.pass();
+        double scoreDelta = round(candidateScore - baselineScore);
+
+        String winner;
+        if (candidatePass && !baselinePass) {
+            winner = "CANDIDATE";
+        } else if (!candidatePass && baselinePass) {
+            winner = "BASELINE";
+        } else if (Math.abs(scoreDelta) < 0.01d) {
+            winner = "TIE";
+        } else {
+            winner = scoreDelta > 0 ? "CANDIDATE" : "BASELINE";
+        }
+
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("candidateOverallScore", round(candidateScore));
+        summary.put("baselineOverallScore", round(baselineScore));
+        summary.put("candidatePass", candidatePass);
+        summary.put("baselinePass", baselinePass);
+        summary.put("scoreDelta", scoreDelta);
+        summary.put("winner", winner);
+        return summary;
+    }
+
+    private String buildFinalPrompt(PromptVersion version, EvalTestCase testCase) {
+        Map<String, String> variables = new LinkedHashMap<>();
+        variables.put("question", testCase.getInputText());
+
+        if (testCase.getContextJson() != null) {
+            for (Map.Entry<String, Object> entry : testCase.getContextJson().entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) {
+                    continue;
+                }
+                variables.put(entry.getKey(), String.valueOf(entry.getValue()));
+            }
+            if (!variables.containsKey("context")) {
+                variables.put("context", toJson(testCase.getContextJson()));
+            }
+        }
+
+        String userTemplate = version.getUserTemplate();
+        if (userTemplate == null || userTemplate.isBlank()) {
+            userTemplate = "{{question}}";
+        }
+        String renderedUser = renderTemplate(userTemplate, variables);
+
+        String systemTemplate = version.getSystemPrompt();
+        String renderedSystem = (systemTemplate == null || systemTemplate.isBlank())
+                ? null
+                : renderTemplate(systemTemplate, variables);
+
+        if (renderedSystem == null || renderedSystem.isBlank()) {
+            return renderedUser;
+        }
+        return renderedSystem + "\n\n" + renderedUser;
+    }
+
+    private String renderTemplate(String template, Map<String, String> variables) {
+        String rendered = template;
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue() == null ? "" : entry.getValue();
+            rendered = rendered.replace("{{" + key + "}}", value);
+            rendered = rendered.replace("{" + key + "}", value);
+        }
+        return rendered;
+    }
+
+    private String sanitizeMessage(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        if (value.length() > 400) {
+            return value.substring(0, 400);
+        }
+        return value;
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception exception) {
+            return String.valueOf(value);
+        }
+    }
+
+    private static Double readTemperature(Map<String, Object> modelConfig) {
+        if (modelConfig == null) {
+            return null;
+        }
+        Object value = modelConfig.get("temperature");
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(String.valueOf(value));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Integer readMaxOutputTokens(Map<String, Object> modelConfig) {
+        if (modelConfig == null) {
+            return null;
+        }
+        Object value = modelConfig.get("maxOutputTokens");
+        if (value == null) {
+            value = modelConfig.get("maxTokens");
+        }
+        if (value == null) {
+            value = modelConfig.get("max_output_tokens");
+        }
+        if (value == null) {
+            value = modelConfig.get("max_tokens");
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            int parsed = Integer.parseInt(String.valueOf(value));
+            return parsed > 0 ? parsed : null;
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Integer resolveMaxOutputTokens(
+            com.llm_ops.demo.keys.domain.ProviderType provider,
+            Map<String, Object> modelConfig
+    ) {
+        if (provider == com.llm_ops.demo.keys.domain.ProviderType.OPENAI) {
+            return null;
+        }
+        return readMaxOutputTokens(modelConfig);
+    }
+
+    private static double round(double value) {
+        return java.math.BigDecimal.valueOf(value)
+                .setScale(2, java.math.RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+}

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
@@ -32,7 +32,9 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -166,8 +168,9 @@ public class EvalExecutionService {
         int inFlight = 0;
 
         while (iterator.hasNext() && inFlight < perRunConcurrency && !isRunCancellationRequested(runId)) {
-            submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration);
-            inFlight++;
+            if (submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration)) {
+                inFlight++;
+            }
         }
 
         while (inFlight > 0) {
@@ -183,8 +186,9 @@ public class EvalExecutionService {
             }
 
             while (iterator.hasNext() && inFlight < perRunConcurrency && !isRunCancellationRequested(runId)) {
-                submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration);
-                inFlight++;
+                if (submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration)) {
+                    inFlight++;
+                }
             }
         }
 
@@ -193,27 +197,40 @@ public class EvalExecutionService {
         }
     }
 
-    private void submitCaseTask(
+    private boolean submitCaseTask(
             CompletionService<CaseExecutionResult> completionService,
             Long runId,
             Long caseResultId,
             ResolvedRubricConfig rubric,
             PromptVersion baselineVersion,
             Duration runLeaseDuration
-    ) {
-        completionService.submit(() -> {
-            long caseStartNanos = System.nanoTime();
-            evalCaseExecutionService.executeCase(
-                    runId,
-                    caseResultId,
-                    rubric,
-                    baselineVersion != null ? baselineVersion.getId() : null,
-                    runLeaseDuration
-            );
-            EvalCaseResult updated = evalCaseResultRepository.findById(caseResultId).orElse(null);
-            String caseStatus = updated != null && updated.status() != null ? updated.status().name() : "unknown";
-            return new CaseExecutionResult(caseStatus, System.nanoTime() - caseStartNanos);
-        });
+    ) throws InterruptedException {
+        while (true) {
+            if (isRunCancellationRequested(runId)) {
+                return false;
+            }
+            try {
+                completionService.submit(() -> {
+                    long caseStartNanos = System.nanoTime();
+                    evalCaseExecutionService.executeCase(
+                            runId,
+                            caseResultId,
+                            rubric,
+                            baselineVersion != null ? baselineVersion.getId() : null,
+                            runLeaseDuration
+                    );
+                    EvalCaseResult updated = evalCaseResultRepository.findById(caseResultId).orElse(null);
+                    String caseStatus = updated != null && updated.status() != null ? updated.status().name() : "unknown";
+                    return new CaseExecutionResult(caseStatus, System.nanoTime() - caseStartNanos);
+                });
+                return true;
+            } catch (RejectedExecutionException exception) {
+                if (evalCaseExecutor.isShutdown()) {
+                    throw new IllegalStateException("evalCaseExecutor is shutting down", exception);
+                }
+                TimeUnit.MILLISECONDS.sleep(10L);
+            }
+        }
     }
 
     private boolean failRunIfTimedOut(EvalRun run, String phase) {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
@@ -28,8 +28,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -47,6 +53,8 @@ public class EvalExecutionService {
     private final EvalJudgeService evalJudgeService;
     private final EvalReleaseCriteriaService evalReleaseCriteriaService;
     private final EvalReleaseDecisionCalculator evalReleaseDecisionCalculator;
+    private final EvalCaseExecutionService evalCaseExecutionService;
+    private final ThreadPoolExecutor evalCaseExecutor;
     private final ObjectMapper objectMapper;
     private final EvalMetrics evalMetrics;
     private final EvalProperties evalProperties;
@@ -62,6 +70,8 @@ public class EvalExecutionService {
             EvalJudgeService evalJudgeService,
             EvalReleaseCriteriaService evalReleaseCriteriaService,
             EvalReleaseDecisionCalculator evalReleaseDecisionCalculator,
+            EvalCaseExecutionService evalCaseExecutionService,
+            @Qualifier("evalCaseExecutor") ThreadPoolExecutor evalCaseExecutor,
             ObjectMapper objectMapper,
             EvalProperties evalProperties,
             EvalMetrics evalMetrics
@@ -76,6 +86,8 @@ public class EvalExecutionService {
         this.evalJudgeService = evalJudgeService;
         this.evalReleaseCriteriaService = evalReleaseCriteriaService;
         this.evalReleaseDecisionCalculator = evalReleaseDecisionCalculator;
+        this.evalCaseExecutionService = evalCaseExecutionService;
+        this.evalCaseExecutor = evalCaseExecutor;
         this.objectMapper = objectMapper;
         this.evalProperties = evalProperties;
         this.evalMetrics = evalMetrics;
@@ -86,22 +98,29 @@ public class EvalExecutionService {
         if (run == null) {
             return;
         }
-        if (run.status() != EvalRunStatus.QUEUED && run.status() != EvalRunStatus.RUNNING) {
+        if (run.status() != EvalRunStatus.QUEUED
+                && run.status() != EvalRunStatus.CLAIMED
+                && run.status() != EvalRunStatus.RUNNING
+                && run.status() != EvalRunStatus.CANCEL_REQUESTED) {
             return;
         }
         long timeoutMinutes = evalProperties.getRunTimeoutMinutes();
         Duration timeoutDuration = Duration.ofMinutes(timeoutMinutes);
+        Duration runLeaseDuration = Duration.ofSeconds(Math.max(30L, evalProperties.getWorker().getRunLeaseSeconds()));
         if (run.status() == EvalRunStatus.QUEUED) {
-            run.markRunningWithTimeout(timeoutDuration);
+            run.markClaimed("INLINE", runLeaseDuration);
+            run.markRunningWithTimeout(timeoutDuration, runLeaseDuration);
             evalRunRepository.save(run);
-        } else if (run.ensureTimeoutIfMissing(timeoutDuration)) {
+        } else if (run.status() == EvalRunStatus.CLAIMED) {
+            run.markRunningWithTimeout(timeoutDuration, runLeaseDuration);
+            evalRunRepository.save(run);
+        } else if (run.ensureTimeoutIfMissing(timeoutDuration, runLeaseDuration)) {
             evalRunRepository.save(run);
         }
 
         if (failRunIfTimedOut(run, "at start")) {
             return;
         }
-        CostAccumulator costAccumulator = new CostAccumulator();
 
         try {
             ResolvedRubricConfig rubric = evalRubricTemplateRegistry.resolve(
@@ -111,40 +130,90 @@ public class EvalExecutionService {
 
             PromptVersion baselineVersion = resolveBaselineVersion(run);
             boolean compareBaselineAvailable = run.mode() != EvalMode.COMPARE_ACTIVE || baselineVersion != null;
-            List<EvalCaseResult> caseResults = evalCaseResultRepository.findByEvalRunIdOrderByIdAsc(run.getId());
+            List<Long> queuedCaseIds = evalCaseResultRepository.findByEvalRunIdOrderByIdAsc(run.getId())
+                    .stream()
+                    .filter(caseResult -> caseResult.status() == EvalCaseStatus.QUEUED)
+                    .map(EvalCaseResult::getId)
+                    .toList();
 
-            for (EvalCaseResult caseResult : caseResults) {
-                if (isRunCancelled(run.getId())) {
-                    log.info("Eval run cancelled while processing. runId={}", run.getId());
-                    return;
-                }
-                if (caseResult.status() != EvalCaseStatus.QUEUED) {
-                    continue;
-                }
-
-                EvalRun currentRun = evalRunRepository.findById(run.getId()).orElseThrow();
-                if (failRunIfTimedOut(currentRun, "during case processing")) {
-                    return;
-                }
-                long caseStartNanos = System.nanoTime();
-                String caseStatus = "unknown";
-                try {
-                    processCase(run, caseResult, rubric, baselineVersion, costAccumulator);
-                    caseStatus = caseResult.status() != null ? caseResult.status().name() : "unknown";
-                } finally {
-                    evalMetrics.recordCaseExecution(caseStatus, System.nanoTime() - caseStartNanos);
-                }
-            }
+            runCasesInParallel(run.getId(), queuedCaseIds, rubric, baselineVersion, runLeaseDuration);
 
             EvalRun finalRun = evalRunRepository.findById(run.getId()).orElseThrow();
             if (failRunIfTimedOut(finalRun, "before finalize")) {
                 return;
             }
-            finishRun(run.getId(), costAccumulator, compareBaselineAvailable);
+            if (finalRun.status() == EvalRunStatus.CANCEL_REQUESTED || finalRun.status() == EvalRunStatus.CANCELLED) {
+                cancelRun(run.getId());
+                return;
+            }
+            finishRun(run.getId(), compareBaselineAvailable);
         } catch (Exception e) {
             log.error("Eval run failed. runId={}", runId, e);
-            failRun(runId, costAccumulator, e.getMessage());
+            failRun(runId, e.getMessage());
         }
+    }
+
+    private void runCasesInParallel(
+            Long runId,
+            List<Long> queuedCaseIds,
+            ResolvedRubricConfig rubric,
+            PromptVersion baselineVersion,
+            Duration runLeaseDuration
+    ) throws InterruptedException, ExecutionException {
+        int perRunConcurrency = Math.max(1, evalProperties.getExecution().getMaxConcurrentCasesPerRun());
+        CompletionService<CaseExecutionResult> completionService = new ExecutorCompletionService<>(evalCaseExecutor);
+        java.util.Iterator<Long> iterator = queuedCaseIds.iterator();
+        int inFlight = 0;
+
+        while (iterator.hasNext() && inFlight < perRunConcurrency && !isRunCancellationRequested(runId)) {
+            submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration);
+            inFlight++;
+        }
+
+        while (inFlight > 0) {
+            Future<CaseExecutionResult> future = completionService.take();
+            CaseExecutionResult result = future.get();
+            inFlight--;
+            evalMetrics.recordCaseExecution(result.caseStatus(), result.elapsedNanos());
+            refreshRunLease(runId, runLeaseDuration);
+
+            EvalRun currentRun = evalRunRepository.findById(runId).orElseThrow();
+            if (failRunIfTimedOut(currentRun, "during case processing")) {
+                return;
+            }
+
+            while (iterator.hasNext() && inFlight < perRunConcurrency && !isRunCancellationRequested(runId)) {
+                submitCaseTask(completionService, runId, iterator.next(), rubric, baselineVersion, runLeaseDuration);
+                inFlight++;
+            }
+        }
+
+        if (isRunCancellationRequested(runId)) {
+            skipQueuedCases(runId);
+        }
+    }
+
+    private void submitCaseTask(
+            CompletionService<CaseExecutionResult> completionService,
+            Long runId,
+            Long caseResultId,
+            ResolvedRubricConfig rubric,
+            PromptVersion baselineVersion,
+            Duration runLeaseDuration
+    ) {
+        completionService.submit(() -> {
+            long caseStartNanos = System.nanoTime();
+            evalCaseExecutionService.executeCase(
+                    runId,
+                    caseResultId,
+                    rubric,
+                    baselineVersion != null ? baselineVersion.getId() : null,
+                    runLeaseDuration
+            );
+            EvalCaseResult updated = evalCaseResultRepository.findById(caseResultId).orElse(null);
+            String caseStatus = updated != null && updated.status() != null ? updated.status().name() : "unknown";
+            return new CaseExecutionResult(caseStatus, System.nanoTime() - caseStartNanos);
+        });
     }
 
     private boolean failRunIfTimedOut(EvalRun run, String phase) {
@@ -156,6 +225,36 @@ public class EvalExecutionService {
         evalRunRepository.save(run);
         log.warn("Eval run timed out {}. runId={}", phase, run.getId());
         return true;
+    }
+
+    private void refreshRunLease(Long runId, Duration runLeaseDuration) {
+        EvalRun run = evalRunRepository.findById(runId).orElse(null);
+        if (run == null) {
+            return;
+        }
+        if (run.status() != EvalRunStatus.RUNNING && run.status() != EvalRunStatus.CANCEL_REQUESTED) {
+            return;
+        }
+        run.heartbeat(runLeaseDuration);
+        evalRunRepository.save(run);
+    }
+
+    private boolean isRunCancellationRequested(Long runId) {
+        return evalRunRepository.findById(runId)
+                .map(EvalRun::isCancellationRequested)
+                .orElse(true);
+    }
+
+    private void skipQueuedCases(Long runId) {
+        List<EvalCaseResult> queuedCases = evalCaseResultRepository.findByEvalRunIdAndStatusOrderByIdAsc(
+                runId,
+                EvalCaseStatus.QUEUED.name()
+        );
+        if (queuedCases.isEmpty()) {
+            return;
+        }
+        queuedCases.forEach(caseResult -> caseResult.markSkipped("RUN_CANCELLED", "실행 중 취소되어 시작되지 않은 케이스입니다."));
+        evalCaseResultRepository.saveAll(queuedCases);
     }
 
     private void processCase(
@@ -406,16 +505,24 @@ public class EvalExecutionService {
                 .orElse(true);
     }
 
-    private void finishRun(Long runId, CostAccumulator costAccumulator, boolean compareBaselineAvailable) {
+    private void finishRun(Long runId, boolean compareBaselineAvailable) {
         EvalRun run = evalRunRepository.findById(runId).orElse(null);
         if (run == null || run.status() == EvalRunStatus.CANCELLED) {
             return;
         }
 
         List<EvalCaseResult> allResults = evalCaseResultRepository.findByEvalRunIdOrderByIdAsc(runId);
+        CaseCountSummary caseCounts = summarizeCaseCounts(allResults);
+        run.syncCaseCounts(
+                caseCounts.processedCases(),
+                caseCounts.passedCases(),
+                caseCounts.failedCases(),
+                caseCounts.errorCases()
+        );
         List<EvalCaseResult> okResults = allResults.stream()
                 .filter(result -> result.status() == EvalCaseStatus.OK)
                 .toList();
+        CostAccumulator costAccumulator = aggregateCaseCosts(allResults);
 
         double avgScore = okResults.stream()
                 .map(EvalCaseResult::getOverallScore)
@@ -424,11 +531,11 @@ public class EvalExecutionService {
                 .average()
                 .orElse(0.0);
 
-        double passRate = run.getProcessedCases() > 0
-                ? (run.getPassedCases() * 100.0) / run.getProcessedCases()
+        double passRate = caseCounts.processedCases() > 0
+                ? (caseCounts.passedCases() * 100.0) / caseCounts.processedCases()
                 : 0.0;
-        double errorRate = run.getProcessedCases() > 0
-                ? (run.getErrorCases() * 100.0) / run.getProcessedCases()
+        double errorRate = caseCounts.processedCases() > 0
+                ? (caseCounts.errorCases() * 100.0) / caseCounts.processedCases()
                 : 0.0;
         Double avgScoreDelta = run.mode() == EvalMode.COMPARE_ACTIVE
                 ? computeAvgScoreDelta(okResults)
@@ -459,10 +566,11 @@ public class EvalExecutionService {
 
         Map<String, Object> summary = new LinkedHashMap<>();
         summary.put("totalCases", run.getTotalCases());
-        summary.put("processedCases", run.getProcessedCases());
-        summary.put("passedCases", run.getPassedCases());
-        summary.put("failedCases", run.getFailedCases());
-        summary.put("errorCases", run.getErrorCases());
+        summary.put("processedCases", caseCounts.processedCases());
+        summary.put("passedCases", caseCounts.passedCases());
+        summary.put("failedCases", caseCounts.failedCases());
+        summary.put("errorCases", caseCounts.errorCases());
+        summary.put("skippedCases", caseCounts.skippedCases());
         summary.put("passRate", round(passRate));
         summary.put("avgOverallScore", round(avgScore));
         summary.put("errorRate", round(errorRate));
@@ -509,35 +617,74 @@ public class EvalExecutionService {
         );
         summary.put("topIssues", topIssues);
         summary.put("plainSummary", buildPlainSummary(releaseDecision, passRate, avgScore, avgScoreDelta, topIssues));
-        appendRunOverallReview(run, summary, allResults, costAccumulator);
+        Map<String, Object> reviewMeta = appendRunOverallReview(run, summary, allResults);
+        costAccumulator.add(reviewMeta);
 
         run.finish(summary, costAccumulator.asMap());
         evalRunRepository.save(run);
     }
 
-    private void failRun(Long runId, CostAccumulator costAccumulator, String reason) {
+    private void failRun(Long runId, String reason) {
         EvalRun run = evalRunRepository.findById(runId).orElse(null);
         if (run == null || run.status() == EvalRunStatus.CANCELLED) {
             return;
         }
 
+        List<EvalCaseResult> allResults = evalCaseResultRepository.findByEvalRunIdOrderByIdAsc(runId);
+        CaseCountSummary caseCounts = summarizeCaseCounts(allResults);
+        run.syncCaseCounts(
+                caseCounts.processedCases(),
+                caseCounts.passedCases(),
+                caseCounts.failedCases(),
+                caseCounts.errorCases()
+        );
+        CostAccumulator costAccumulator = aggregateCaseCosts(allResults);
         Map<String, Object> summary = new LinkedHashMap<>();
         summary.put("totalCases", run.getTotalCases());
-        summary.put("processedCases", run.getProcessedCases());
-        summary.put("passedCases", run.getPassedCases());
-        summary.put("failedCases", run.getFailedCases());
-        summary.put("errorCases", run.getErrorCases());
+        summary.put("processedCases", caseCounts.processedCases());
+        summary.put("passedCases", caseCounts.passedCases());
+        summary.put("failedCases", caseCounts.failedCases());
+        summary.put("errorCases", caseCounts.errorCases());
+        summary.put("skippedCases", caseCounts.skippedCases());
         summary.put("failReason", sanitizeMessage(reason));
 
         run.fail(summary, costAccumulator.asMap());
         evalRunRepository.save(run);
     }
 
-    private void appendRunOverallReview(
+    private void cancelRun(Long runId) {
+        EvalRun run = evalRunRepository.findById(runId).orElse(null);
+        if (run == null) {
+            return;
+        }
+
+        List<EvalCaseResult> allResults = evalCaseResultRepository.findByEvalRunIdOrderByIdAsc(runId);
+        CaseCountSummary caseCounts = summarizeCaseCounts(allResults);
+        run.syncCaseCounts(
+                caseCounts.processedCases(),
+                caseCounts.passedCases(),
+                caseCounts.failedCases(),
+                caseCounts.errorCases()
+        );
+        CostAccumulator costAccumulator = aggregateCaseCosts(allResults);
+
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("totalCases", run.getTotalCases());
+        summary.put("processedCases", caseCounts.processedCases());
+        summary.put("passedCases", caseCounts.passedCases());
+        summary.put("failedCases", caseCounts.failedCases());
+        summary.put("errorCases", caseCounts.errorCases());
+        summary.put("skippedCases", caseCounts.skippedCases());
+        summary.put("failReason", "사용자 요청으로 실행이 취소되었습니다.");
+
+        run.cancel(summary, costAccumulator.asMap());
+        evalRunRepository.save(run);
+    }
+
+    private Map<String, Object> appendRunOverallReview(
             EvalRun run,
             Map<String, Object> summary,
-            List<EvalCaseResult> allResults,
-            CostAccumulator costAccumulator
+            List<EvalCaseResult> allResults
     ) {
         try {
             Long organizationId = run.getPrompt().getWorkspace().getOrganization().getId();
@@ -549,10 +696,11 @@ public class EvalExecutionService {
                     caseHighlights
             );
             summary.put("llmOverallReview", reviewResult.review());
-            costAccumulator.add(reviewResult.meta());
+            return reviewResult.meta();
         } catch (Exception e) {
             log.warn("Run overall review generation failed. runId={}", run.getId(), e);
             summary.put("llmOverallReview", fallbackRunOverallReview(sanitizeMessage(e.getMessage())));
+            return Map.of();
         }
     }
 
@@ -811,6 +959,42 @@ public class EvalExecutionService {
         return sortCountsDesc(counts);
     }
 
+    private CaseCountSummary summarizeCaseCounts(List<EvalCaseResult> allResults) {
+        int processed = 0;
+        int passed = 0;
+        int failed = 0;
+        int error = 0;
+        int skipped = 0;
+
+        for (EvalCaseResult result : allResults) {
+            if (result.status() == EvalCaseStatus.OK) {
+                processed++;
+                if (Boolean.TRUE.equals(result.getPass())) {
+                    passed++;
+                } else {
+                    failed++;
+                }
+            } else if (result.status() == EvalCaseStatus.ERROR) {
+                processed++;
+                error++;
+            } else if (result.status() == EvalCaseStatus.SKIPPED) {
+                skipped++;
+            }
+        }
+        return new CaseCountSummary(processed, passed, failed, error, skipped);
+    }
+
+    private CostAccumulator aggregateCaseCosts(List<EvalCaseResult> allResults) {
+        CostAccumulator accumulator = new CostAccumulator();
+        for (EvalCaseResult result : allResults) {
+            accumulator.add(result.getCandidateMetaJson());
+            accumulator.add(result.getBaselineMetaJson());
+            accumulator.add(extractJudgeMeta(result.getJudgeOutputJson()));
+            accumulator.add(extractBaselineJudgeMeta(result.getJudgeOutputJson()));
+        }
+        return accumulator;
+    }
+
     private List<Map<String, Object>> collectMetaMaps(List<EvalCaseResult> results, boolean candidate) {
         List<Map<String, Object>> metas = new ArrayList<>();
         for (EvalCaseResult result : results) {
@@ -821,6 +1005,32 @@ public class EvalExecutionService {
             metas.add(meta);
         }
         return metas;
+    }
+
+    private Map<String, Object> extractJudgeMeta(Map<String, Object> judgeOutput) {
+        if (judgeOutput == null) {
+            return Map.of();
+        }
+        Object judgeMeta = judgeOutput.get("judgeMeta");
+        if (!(judgeMeta instanceof Map<?, ?> judgeMetaMap)) {
+            return Map.of();
+        }
+        return castObjectMap(judgeMetaMap);
+    }
+
+    private Map<String, Object> extractBaselineJudgeMeta(Map<String, Object> judgeOutput) {
+        if (judgeOutput == null) {
+            return Map.of();
+        }
+        Object baseline = judgeOutput.get("baseline");
+        if (!(baseline instanceof Map<?, ?> baselineMap)) {
+            return Map.of();
+        }
+        Object judgeMeta = baselineMap.get("judgeMeta");
+        if (!(judgeMeta instanceof Map<?, ?> judgeMetaMap)) {
+            return Map.of();
+        }
+        return castObjectMap(judgeMetaMap);
     }
 
     private Map<String, Object> extractCandidateRuleChecks(Map<String, Object> ruleChecks) {
@@ -934,6 +1144,18 @@ public class EvalExecutionService {
 
     private static double round(double value) {
         return BigDecimal.valueOf(value).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    private record CaseExecutionResult(String caseStatus, long elapsedNanos) {
+    }
+
+    private record CaseCountSummary(
+            int processedCases,
+            int passedCases,
+            int failedCases,
+            int errorCases,
+            int skippedCases
+    ) {
     }
 
     private static final class CostAccumulator {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalModelRunnerService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalModelRunnerService.java
@@ -100,14 +100,11 @@ public class EvalModelRunnerService {
         long startedAtNanos = System.nanoTime();
         for (int attempt = 1; attempt <= sameProviderTotalAttempts; attempt++) {
             try {
-                ChatResponse response;
-                try (EvalProviderConcurrencyLimiter.Permit ignored = evalProviderConcurrencyLimiter.acquire(provider)) {
-                    response = circuitBreaker.executeCallable(() -> switch (provider) {
-                        case OPENAI -> callOpenAi(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                        case ANTHROPIC -> callAnthropic(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                        case GEMINI -> callGemini(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                    });
-                }
+                ChatResponse response = circuitBreaker.executeCallable(() -> switch (provider) {
+                    case OPENAI -> callOpenAi(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                    case ANTHROPIC -> callAnthropic(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                    case GEMINI -> callGemini(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                });
                 int retryCount = attempt - 1;
                 return toExecution(provider, model, response, startedAtNanos, retryCount);
             } catch (Exception exception) {
@@ -373,7 +370,11 @@ public class EvalModelRunnerService {
             java.util.concurrent.Callable<ChatResponse> providerCall
     ) {
         long timeoutMs = Math.max(1_000L, evalProperties.getRunner().getRequestTimeoutMs());
-        Future<ChatResponse> future = PROVIDER_CALL_EXECUTOR.submit(providerCall);
+        Future<ChatResponse> future = PROVIDER_CALL_EXECUTOR.submit(() -> {
+            try (EvalProviderConcurrencyLimiter.Permit ignored = evalProviderConcurrencyLimiter.acquire(providerType)) {
+                return providerCall.call();
+            }
+        });
         try {
             return future.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (TimeoutException timeoutException) {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalModelRunnerService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalModelRunnerService.java
@@ -59,17 +59,20 @@ public class EvalModelRunnerService {
     private final ProviderCredentialService providerCredentialService;
     private final GatewayChatOptionsCreateService gatewayChatOptionsCreateService;
     private final CircuitBreakerRegistry circuitBreakerRegistry;
+    private final EvalProviderConcurrencyLimiter evalProviderConcurrencyLimiter;
 
     public EvalModelRunnerService(
             EvalProperties evalProperties,
             ProviderCredentialService providerCredentialService,
             GatewayChatOptionsCreateService gatewayChatOptionsCreateService,
-            CircuitBreakerRegistry circuitBreakerRegistry
+            CircuitBreakerRegistry circuitBreakerRegistry,
+            EvalProviderConcurrencyLimiter evalProviderConcurrencyLimiter
     ) {
         this.evalProperties = evalProperties;
         this.providerCredentialService = providerCredentialService;
         this.gatewayChatOptionsCreateService = gatewayChatOptionsCreateService;
         this.circuitBreakerRegistry = circuitBreakerRegistry;
+        this.evalProviderConcurrencyLimiter = evalProviderConcurrencyLimiter;
     }
 
     public ModelExecution run(
@@ -97,11 +100,14 @@ public class EvalModelRunnerService {
         long startedAtNanos = System.nanoTime();
         for (int attempt = 1; attempt <= sameProviderTotalAttempts; attempt++) {
             try {
-                ChatResponse response = circuitBreaker.executeCallable(() -> switch (provider) {
-                    case OPENAI -> callOpenAi(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                    case ANTHROPIC -> callAnthropic(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                    case GEMINI -> callGemini(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
-                });
+                ChatResponse response;
+                try (EvalProviderConcurrencyLimiter.Permit ignored = evalProviderConcurrencyLimiter.acquire(provider)) {
+                    response = circuitBreaker.executeCallable(() -> switch (provider) {
+                        case OPENAI -> callOpenAi(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                        case ANTHROPIC -> callAnthropic(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                        case GEMINI -> callGemini(resolved.apiKey(), model, prompt, temperature, maxOutputTokens);
+                    });
+                }
                 int retryCount = attempt - 1;
                 return toExecution(provider, model, response, startedAtNanos, retryCount);
             } catch (Exception exception) {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalProviderConcurrencyLimiter.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalProviderConcurrencyLimiter.java
@@ -1,0 +1,49 @@
+package com.llm_ops.demo.eval.service;
+
+import com.llm_ops.demo.eval.config.EvalProperties;
+import com.llm_ops.demo.global.error.BusinessException;
+import com.llm_ops.demo.global.error.ErrorCode;
+import com.llm_ops.demo.keys.domain.ProviderType;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EvalProviderConcurrencyLimiter {
+
+    private final Map<ProviderType, Semaphore> permits = new EnumMap<>(ProviderType.class);
+
+    public EvalProviderConcurrencyLimiter(EvalProperties evalProperties) {
+        EvalProperties.ProviderLimits providerLimits = evalProperties.getRunner().getProviderLimits();
+        permits.put(ProviderType.OPENAI, new Semaphore(Math.max(1, providerLimits.getOpenaiMaxConcurrentCalls()), true));
+        permits.put(ProviderType.ANTHROPIC, new Semaphore(Math.max(1, providerLimits.getAnthropicMaxConcurrentCalls()), true));
+        permits.put(ProviderType.GEMINI, new Semaphore(Math.max(1, providerLimits.getGeminiMaxConcurrentCalls()), true));
+    }
+
+    public Permit acquire(ProviderType providerType) {
+        Semaphore semaphore = permits.get(providerType);
+        if (semaphore == null) {
+            return Permit.NOOP;
+        }
+        try {
+            semaphore.acquire();
+            return () -> semaphore.release();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    providerType.name() + " provider 동시성 대기 중 인터럽트되었습니다."
+            );
+        }
+    }
+
+    @FunctionalInterface
+    public interface Permit extends AutoCloseable {
+        Permit NOOP = () -> {
+        };
+
+        @Override
+        void close();
+    }
+}

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalRunService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalRunService.java
@@ -285,7 +285,7 @@ public class EvalRunService {
     public EvalCancelResponse cancelRun(Long workspaceId, Long promptId, Long runId, Long userId) {
         EvalAccessService.PromptScope scope = evalAccessService.requirePromptScope(workspaceId, promptId, userId);
         EvalRun run = evalAccessService.requireRun(scope.prompt(), runId);
-        run.markCancelled();
+        run.requestCancel();
         return new EvalCancelResponse(run.getId(), run.status().name());
     }
 
@@ -430,21 +430,38 @@ public class EvalRunService {
     }
 
     @Transactional
-    public List<EvalRun> pickQueuedRuns(int batchSize) {
-        int safeBatchSize = Math.max(batchSize, 1);
-        List<EvalRun> queuedRuns = evalRunRepository.findQueuedRunsForUpdate(
-                EvalRunStatus.QUEUED.name(),
-                PageRequest.of(0, safeBatchSize)
-        );
-
-        if (queuedRuns.isEmpty()) {
-            return queuedRuns;
+    public List<EvalRun> claimQueuedRuns(int desiredCount, String leaseOwner, Duration claimLeaseDuration) {
+        int safeCount = Math.max(desiredCount, 0);
+        if (safeCount == 0) {
+            return List.of();
         }
 
-        long timeoutMinutes = evalProperties.getRunTimeoutMinutes();
-        Duration timeoutDuration = Duration.ofMinutes(timeoutMinutes);
-        queuedRuns.forEach(run -> run.markRunningWithTimeout(timeoutDuration));
+        int claimBatchSize = Math.max(1, evalProperties.getWorker().getClaimBatchSize());
+        int limit = Math.min(safeCount, claimBatchSize);
+        List<Long> runIds = evalRunRepository.findQueuedRunIdsForClaim(EvalRunStatus.QUEUED.name(), limit);
+        if (runIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<EvalRun> queuedRuns = evalRunRepository.findByIdInOrderByCreatedAtAsc(runIds);
+        queuedRuns.forEach(run -> run.markClaimed(leaseOwner, claimLeaseDuration));
         return evalRunRepository.saveAll(queuedRuns);
+    }
+
+    @Transactional
+    public void releaseClaimToQueue(Long runId, String leaseOwner) {
+        EvalRun run = evalRunRepository.findById(runId).orElse(null);
+        if (run == null) {
+            return;
+        }
+        if (run.status() != EvalRunStatus.CLAIMED) {
+            return;
+        }
+        if (leaseOwner != null && run.getLeaseOwner() != null && !leaseOwner.equals(run.getLeaseOwner())) {
+            return;
+        }
+        run.resetToQueued();
+        evalRunRepository.save(run);
     }
 
     private PromptVersion resolveBaselineVersionForEstimate(Prompt prompt, PromptVersion candidateVersion, EvalMode mode) {
@@ -693,15 +710,21 @@ public class EvalRunService {
 
     @Transactional
     public int recoverStuckRuns(Duration timeout) {
-        LocalDateTime cutoffTime = LocalDateTime.now().minus(timeout);
+        LocalDateTime claimCutoffTime = LocalDateTime.now();
+        LocalDateTime runTimeoutCutoff = LocalDateTime.now().minus(timeout);
         int totalRecovered = 0;
         int batchSize = 50;
         List<EvalRun> stuckRuns;
 
         do {
-            stuckRuns = evalRunRepository.findStuckRunsForUpdate(
-                    EvalRunStatus.RUNNING.name(),
-                    cutoffTime,
+            stuckRuns = evalRunRepository.findRecoverableRunsForUpdate(
+                    List.of(
+                            EvalRunStatus.CLAIMED.name(),
+                            EvalRunStatus.RUNNING.name(),
+                            EvalRunStatus.CANCEL_REQUESTED.name()
+                    ),
+                    claimCutoffTime,
+                    runTimeoutCutoff,
                     PageRequest.of(0, batchSize)
             );
 

--- a/src/main/java/com/llm_ops/demo/eval/worker/EvalWorker.java
+++ b/src/main/java/com/llm_ops/demo/eval/worker/EvalWorker.java
@@ -5,8 +5,12 @@ import com.llm_ops.demo.eval.service.EvalExecutionService;
 import com.llm_ops.demo.eval.service.EvalMetrics;
 import com.llm_ops.demo.eval.service.EvalRunService;
 import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,17 +25,21 @@ public class EvalWorker {
     private final EvalExecutionService evalExecutionService;
     private final EvalProperties evalProperties;
     private final EvalMetrics evalMetrics;
+    private final ThreadPoolExecutor evalRunExecutor;
+    private final String leaseOwner = "eval-worker-" + UUID.randomUUID();
 
     public EvalWorker(
             EvalRunService evalRunService,
             EvalExecutionService evalExecutionService,
             EvalProperties evalProperties,
-            EvalMetrics evalMetrics
+            EvalMetrics evalMetrics,
+            @Qualifier("evalRunExecutor") ThreadPoolExecutor evalRunExecutor
     ) {
         this.evalRunService = evalRunService;
         this.evalExecutionService = evalExecutionService;
         this.evalProperties = evalProperties;
         this.evalMetrics = evalMetrics;
+        this.evalRunExecutor = evalRunExecutor;
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -48,22 +56,31 @@ public class EvalWorker {
 
     @Scheduled(fixedDelayString = "${eval.worker.poll-interval-ms:3000}")
     public void pollQueuedRuns() {
-        int batchSize = Math.max(1, evalProperties.getWorker().getBatchSize());
-        evalRunService.pickQueuedRuns(batchSize)
+        int availableSlots = Math.max(0, evalRunExecutor.getMaximumPoolSize() - evalRunExecutor.getActiveCount());
+        if (availableSlots == 0) {
+            return;
+        }
+
+        Duration claimLeaseDuration = Duration.ofSeconds(Math.max(5L, evalProperties.getWorker().getClaimLeaseSeconds()));
+        evalRunService.claimQueuedRuns(availableSlots, leaseOwner, claimLeaseDuration)
                 .forEach(run -> {
-                    long startNanos = System.nanoTime();
                     try {
-                        evalExecutionService.processRun(run.getId());
-                        evalMetrics.recordRunExecution(
-                                run.mode() != null ? run.mode().name() : "unknown",
-                                "WORKER",
-                                System.nanoTime() - startNanos);
-                    } catch (Exception e) {
-                        evalMetrics.recordRunExecution(
-                                run.mode() != null ? run.mode().name() : "unknown",
-                                "WORKER",
-                                System.nanoTime() - startNanos);
-                        log.error("Eval run processing failed. runId={}", run.getId(), e);
+                        evalRunExecutor.submit(() -> {
+                            long startNanos = System.nanoTime();
+                            try {
+                                evalExecutionService.processRun(run.getId());
+                            } catch (Exception e) {
+                                log.error("Eval run processing failed. runId={}", run.getId(), e);
+                            } finally {
+                                evalMetrics.recordRunExecution(
+                                        run.mode() != null ? run.mode().name() : "unknown",
+                                        "WORKER",
+                                        System.nanoTime() - startNanos);
+                            }
+                        });
+                    } catch (RejectedExecutionException exception) {
+                        log.warn("Eval run executor rejected submission. runId={}", run.getId(), exception);
+                        evalRunService.releaseClaimToQueue(run.getId(), leaseOwner);
                     }
                 });
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -192,7 +192,7 @@ eval:
     poll-interval-ms: 3000
     batch-size: 3
     max-concurrent-runs: 3
-    claim-batch-size: 2
+    claim-batch-size: 3
     claim-lease-seconds: 30
     run-lease-seconds: 900
   execution:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -191,7 +191,7 @@ eval:
   worker:
     poll-interval-ms: 3000
     batch-size: 3
-    max-concurrent-runs: 2
+    max-concurrent-runs: 3
     claim-batch-size: 2
     claim-lease-seconds: 30
     run-lease-seconds: 900

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -191,7 +191,19 @@ eval:
   worker:
     poll-interval-ms: 3000
     batch-size: 3
+    max-concurrent-runs: 2
+    claim-batch-size: 2
+    claim-lease-seconds: 30
+    run-lease-seconds: 900
+  execution:
+    max-concurrent-cases-per-run: 2
+    max-active-cases-global: 6
+    max-case-queue-capacity: 24
   runner:
     request-timeout-ms: 120000
     same-provider-retry-max-attempts: 1
     same-provider-retry-backoff-ms: 200
+    provider-limits:
+      openai-max-concurrent-calls: 4
+      anthropic-max-concurrent-calls: 3
+      gemini-max-concurrent-calls: 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -196,14 +196,14 @@ eval:
     claim-lease-seconds: 30
     run-lease-seconds: 900
   execution:
-    max-concurrent-cases-per-run: 2
-    max-active-cases-global: 6
+    max-concurrent-cases-per-run: 3
+    max-active-cases-global: 9
     max-case-queue-capacity: 24
   runner:
     request-timeout-ms: 120000
     same-provider-retry-max-attempts: 1
     same-provider-retry-backoff-ms: 200
     provider-limits:
-      openai-max-concurrent-calls: 4
+      openai-max-concurrent-calls: 6
       anthropic-max-concurrent-calls: 3
       gemini-max-concurrent-calls: 3

--- a/src/main/resources/db/migration/V32__eval_parallel_execution_state.sql
+++ b/src/main/resources/db/migration/V32__eval_parallel_execution_state.sql
@@ -1,0 +1,16 @@
+-- Prompt Eval parallel execution state and lease fields
+
+ALTER TABLE eval_runs
+    ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS lease_owner VARCHAR(120),
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS cancel_requested_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_status_created_claim
+    ON eval_runs (status, created_at)
+    WHERE status IN ('QUEUED', 'CLAIMED');
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_status_lease_expires
+    ON eval_runs (status, lease_expires_at)
+    WHERE status IN ('CLAIMED', 'RUNNING', 'CANCEL_REQUESTED');

--- a/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
@@ -52,7 +52,7 @@ class EvalPropertiesTest {
         // then
         assertThat(worker.getPollIntervalMs()).isEqualTo(3000L);
         assertThat(worker.getBatchSize()).isEqualTo(3);
-        assertThat(worker.getMaxConcurrentRuns()).isEqualTo(2);
+        assertThat(worker.getMaxConcurrentRuns()).isEqualTo(3);
         assertThat(worker.getClaimBatchSize()).isEqualTo(2);
         assertThat(worker.getClaimLeaseSeconds()).isEqualTo(30L);
         assertThat(worker.getRunLeaseSeconds()).isEqualTo(900L);

--- a/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
@@ -68,8 +68,8 @@ class EvalPropertiesTest {
         EvalProperties.Execution execution = properties.getExecution();
 
         // then
-        assertThat(execution.getMaxConcurrentCasesPerRun()).isEqualTo(2);
-        assertThat(execution.getMaxActiveCasesGlobal()).isEqualTo(6);
+        assertThat(execution.getMaxConcurrentCasesPerRun()).isEqualTo(3);
+        assertThat(execution.getMaxActiveCasesGlobal()).isEqualTo(9);
         assertThat(execution.getMaxCaseQueueCapacity()).isEqualTo(24);
     }
 
@@ -84,7 +84,7 @@ class EvalPropertiesTest {
 
         // then
         assertThat(runner.getRequestTimeoutMs()).isEqualTo(20000L);
-        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(4);
+        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(6);
         assertThat(runner.getProviderLimits().getAnthropicMaxConcurrentCalls()).isEqualTo(3);
         assertThat(runner.getProviderLimits().getGeminiMaxConcurrentCalls()).isEqualTo(3);
     }

--- a/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
@@ -53,7 +53,7 @@ class EvalPropertiesTest {
         assertThat(worker.getPollIntervalMs()).isEqualTo(3000L);
         assertThat(worker.getBatchSize()).isEqualTo(3);
         assertThat(worker.getMaxConcurrentRuns()).isEqualTo(3);
-        assertThat(worker.getClaimBatchSize()).isEqualTo(2);
+        assertThat(worker.getClaimBatchSize()).isEqualTo(3);
         assertThat(worker.getClaimLeaseSeconds()).isEqualTo(30L);
         assertThat(worker.getRunLeaseSeconds()).isEqualTo(900L);
     }
@@ -162,13 +162,13 @@ class EvalPropertiesTest {
 
         // when
         runner.setRequestTimeoutMs(30000L);
-        runner.getProviderLimits().setOpenaiMaxConcurrentCalls(6);
+        runner.getProviderLimits().setOpenaiMaxConcurrentCalls(8);
         runner.getProviderLimits().setAnthropicMaxConcurrentCalls(4);
         runner.getProviderLimits().setGeminiMaxConcurrentCalls(5);
 
         // then
         assertThat(runner.getRequestTimeoutMs()).isEqualTo(30000L);
-        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(6);
+        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(8);
         assertThat(runner.getProviderLimits().getAnthropicMaxConcurrentCalls()).isEqualTo(4);
         assertThat(runner.getProviderLimits().getGeminiMaxConcurrentCalls()).isEqualTo(5);
     }

--- a/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesTest.java
@@ -19,6 +19,7 @@ class EvalPropertiesTest {
         // then
         assertThat(properties.getJudge()).isNotNull();
         assertThat(properties.getWorker()).isNotNull();
+        assertThat(properties.getExecution()).isNotNull();
         assertThat(properties.getRunner()).isNotNull();
     }
 
@@ -51,6 +52,25 @@ class EvalPropertiesTest {
         // then
         assertThat(worker.getPollIntervalMs()).isEqualTo(3000L);
         assertThat(worker.getBatchSize()).isEqualTo(3);
+        assertThat(worker.getMaxConcurrentRuns()).isEqualTo(2);
+        assertThat(worker.getClaimBatchSize()).isEqualTo(2);
+        assertThat(worker.getClaimLeaseSeconds()).isEqualTo(30L);
+        assertThat(worker.getRunLeaseSeconds()).isEqualTo(900L);
+    }
+
+    @Test
+    @DisplayName("Execution 기본값이 올바르게 설정된다")
+    void execution_기본값을_확인한다() {
+        // given
+
+        // when
+        EvalProperties properties = new EvalProperties();
+        EvalProperties.Execution execution = properties.getExecution();
+
+        // then
+        assertThat(execution.getMaxConcurrentCasesPerRun()).isEqualTo(2);
+        assertThat(execution.getMaxActiveCasesGlobal()).isEqualTo(6);
+        assertThat(execution.getMaxCaseQueueCapacity()).isEqualTo(24);
     }
 
     @Test
@@ -64,6 +84,9 @@ class EvalPropertiesTest {
 
         // then
         assertThat(runner.getRequestTimeoutMs()).isEqualTo(20000L);
+        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(4);
+        assertThat(runner.getProviderLimits().getAnthropicMaxConcurrentCalls()).isEqualTo(3);
+        assertThat(runner.getProviderLimits().getGeminiMaxConcurrentCalls()).isEqualTo(3);
     }
 
     @Test
@@ -98,10 +121,36 @@ class EvalPropertiesTest {
         // when
         worker.setPollIntervalMs(5000L);
         worker.setBatchSize(5);
+        worker.setMaxConcurrentRuns(4);
+        worker.setClaimBatchSize(6);
+        worker.setClaimLeaseSeconds(45L);
+        worker.setRunLeaseSeconds(1200L);
 
         // then
         assertThat(worker.getPollIntervalMs()).isEqualTo(5000L);
         assertThat(worker.getBatchSize()).isEqualTo(5);
+        assertThat(worker.getMaxConcurrentRuns()).isEqualTo(4);
+        assertThat(worker.getClaimBatchSize()).isEqualTo(6);
+        assertThat(worker.getClaimLeaseSeconds()).isEqualTo(45L);
+        assertThat(worker.getRunLeaseSeconds()).isEqualTo(1200L);
+    }
+
+    @Test
+    @DisplayName("Execution 설정을 변경할 수 있다")
+    void execution_설정을_변경한다() {
+        // given
+        EvalProperties properties = new EvalProperties();
+        EvalProperties.Execution execution = properties.getExecution();
+
+        // when
+        execution.setMaxConcurrentCasesPerRun(4);
+        execution.setMaxActiveCasesGlobal(10);
+        execution.setMaxCaseQueueCapacity(40);
+
+        // then
+        assertThat(execution.getMaxConcurrentCasesPerRun()).isEqualTo(4);
+        assertThat(execution.getMaxActiveCasesGlobal()).isEqualTo(10);
+        assertThat(execution.getMaxCaseQueueCapacity()).isEqualTo(40);
     }
 
     @Test
@@ -113,8 +162,14 @@ class EvalPropertiesTest {
 
         // when
         runner.setRequestTimeoutMs(30000L);
+        runner.getProviderLimits().setOpenaiMaxConcurrentCalls(6);
+        runner.getProviderLimits().setAnthropicMaxConcurrentCalls(4);
+        runner.getProviderLimits().setGeminiMaxConcurrentCalls(5);
 
         // then
         assertThat(runner.getRequestTimeoutMs()).isEqualTo(30000L);
+        assertThat(runner.getProviderLimits().getOpenaiMaxConcurrentCalls()).isEqualTo(6);
+        assertThat(runner.getProviderLimits().getAnthropicMaxConcurrentCalls()).isEqualTo(4);
+        assertThat(runner.getProviderLimits().getGeminiMaxConcurrentCalls()).isEqualTo(5);
     }
 }

--- a/src/test/java/com/llm_ops/demo/eval/service/EvalExecutionServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/service/EvalExecutionServiceTest.java
@@ -17,6 +17,9 @@ import com.llm_ops.demo.prompt.repository.PromptReleaseRepository;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +39,13 @@ class EvalExecutionServiceTest {
         EvalCaseResultRepository evalCaseResultRepository = mock(EvalCaseResultRepository.class);
         EvalProperties evalProperties = new EvalProperties();
         evalProperties.setRunTimeoutMinutes(30L);
+        ThreadPoolExecutor evalCaseExecutor = new ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>()
+        );
 
         EvalExecutionService service = new EvalExecutionService(
                 evalRunRepository,
@@ -48,6 +58,8 @@ class EvalExecutionServiceTest {
                 mock(EvalJudgeService.class),
                 mock(EvalReleaseCriteriaService.class),
                 mock(EvalReleaseDecisionCalculator.class),
+                mock(EvalCaseExecutionService.class),
+                evalCaseExecutor,
                 new ObjectMapper(),
                 evalProperties,
                 mock(EvalMetrics.class)
@@ -80,5 +92,6 @@ class EvalExecutionServiceTest {
         assertThat(timedOutRun.getFailReasonCode()).isEqualTo("RUN_TIMEOUT");
         verify(evalRunRepository).save(timedOutRun);
         verifyNoInteractions(evalCaseResultRepository);
+        evalCaseExecutor.shutdownNow();
     }
 }

--- a/src/test/java/com/llm_ops/demo/eval/service/EvalModelRunnerServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/service/EvalModelRunnerServiceTest.java
@@ -46,7 +46,8 @@ class EvalModelRunnerServiceTest {
                 evalProperties,
                 providerCredentialService,
                 gatewayChatOptionsCreateService,
-                circuitBreakerRegistry
+                circuitBreakerRegistry,
+                new EvalProviderConcurrencyLimiter(evalProperties)
         );
 
         when(providerCredentialService.resolveApiKey(1L, ProviderType.OPENAI))

--- a/src/test/java/com/llm_ops/demo/eval/service/EvalRunServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/service/EvalRunServiceTest.java
@@ -263,13 +263,15 @@ class EvalRunServiceTest {
     }
 
     @Test
-    @DisplayName("pickQueuedRuns는 조회한 QUEUED run을 RUNNING으로 선점한다")
-    void pickQueuedRuns는_조회한_queued_run을_running으로_선점한다() {
+    @DisplayName("claimQueuedRuns는 조회한 QUEUED run을 CLAIMED로 선점한다")
+    void claimQueuedRuns는_조회한_queued_run을_claimed로_선점한다() {
         // given
         EvalRunRepository evalRunRepository = mock(EvalRunRepository.class);
+        EvalProperties properties = new EvalProperties();
+        properties.getWorker().setClaimBatchSize(3);
         EvalRunService service = new EvalRunService(
                 mock(EvalAccessService.class),
-                new EvalProperties(),
+                properties,
                 evalRunRepository,
                 mock(EvalCaseResultRepository.class),
                 mock(EvalTestCaseRepository.class),
@@ -296,25 +298,22 @@ class EvalRunServiceTest {
                 1L
         );
 
-        when(evalRunRepository.findQueuedRunsForUpdate(eq(EvalRunStatus.QUEUED.name()), any(Pageable.class)))
-                .thenReturn(List.of(queuedRun));
+        when(evalRunRepository.findQueuedRunIdsForClaim(eq(EvalRunStatus.QUEUED.name()), eq(3)))
+                .thenReturn(List.of(1L));
+        when(evalRunRepository.findByIdInOrderByCreatedAtAsc(List.of(1L))).thenReturn(List.of(queuedRun));
         when(evalRunRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        List<EvalRun> picked = service.pickQueuedRuns(3);
+        List<EvalRun> picked = service.claimQueuedRuns(3, "worker-1", Duration.ofSeconds(30));
 
         // then
         assertThat(picked).hasSize(1);
-        assertThat(picked.get(0).status()).isEqualTo(EvalRunStatus.RUNNING);
-        assertThat(picked.get(0).getStartedAt()).isNotNull();
-        assertThat(picked.get(0).getTimeoutAt()).isNotNull();
-        assertThat(picked.get(0).getTimeoutAt()).isAfterOrEqualTo(picked.get(0).getStartedAt());
+        assertThat(picked.get(0).status()).isEqualTo(EvalRunStatus.CLAIMED);
+        assertThat(picked.get(0).getClaimedAt()).isNotNull();
+        assertThat(picked.get(0).getLeaseOwner()).isEqualTo("worker-1");
+        assertThat(picked.get(0).getLeaseExpiresAt()).isAfterOrEqualTo(picked.get(0).getClaimedAt());
         verify(evalRunRepository).saveAll(picked);
-
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        verify(evalRunRepository).findQueuedRunsForUpdate(eq(EvalRunStatus.QUEUED.name()), pageableCaptor.capture());
-        assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(0);
-        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(3);
+        verify(evalRunRepository).findQueuedRunIdsForClaim(EvalRunStatus.QUEUED.name(), 3);
     }
 
     @Test
@@ -351,13 +350,19 @@ class EvalRunServiceTest {
                 1,
                 1L
         );
-        stuckRun.markRunningWithTimeout(Duration.ofMinutes(30));
+        stuckRun.markClaimed("worker-1", Duration.ofSeconds(-1));
+        stuckRun.markRunningWithTimeout(Duration.ofMinutes(30), Duration.ofMinutes(5));
 
         EvalCaseResult runningCase = EvalCaseResult.queue(stuckRun, mock(EvalTestCase.class));
         runningCase.markRunning();
 
-        when(evalRunRepository.findStuckRunsForUpdate(
-                eq(EvalRunStatus.RUNNING.name()),
+        when(evalRunRepository.findRecoverableRunsForUpdate(
+                eq(List.of(
+                        EvalRunStatus.CLAIMED.name(),
+                        EvalRunStatus.RUNNING.name(),
+                        EvalRunStatus.CANCEL_REQUESTED.name()
+                )),
+                any(LocalDateTime.class),
                 any(LocalDateTime.class),
                 any(Pageable.class)
         )).thenReturn(List.of(stuckRun), List.of());

--- a/src/test/java/com/llm_ops/demo/eval/worker/EvalWorkerTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/worker/EvalWorkerTest.java
@@ -1,8 +1,12 @@
 package com.llm_ops.demo.eval.worker;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +18,9 @@ import com.llm_ops.demo.eval.service.EvalMetrics;
 import com.llm_ops.demo.eval.service.EvalRunService;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,12 +31,19 @@ class EvalWorkerTest {
     void 배치_내_단일_run_처리_실패가_발생해도_다음_run_처리를_계속한다() {
         // given
         EvalProperties evalProperties = new EvalProperties();
-        evalProperties.getWorker().setBatchSize(3);
+        evalProperties.getWorker().setMaxConcurrentRuns(3);
 
         EvalRunService evalRunService = mock(EvalRunService.class);
         EvalExecutionService evalExecutionService = mock(EvalExecutionService.class);
         EvalMetrics evalMetrics = mock(EvalMetrics.class);
-        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                3,
+                3,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>()
+        );
+        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics, executor);
 
         EvalRun firstRun = mock(EvalRun.class);
         EvalRun secondRun = mock(EvalRun.class);
@@ -40,17 +54,19 @@ class EvalWorkerTest {
         when(secondRun.mode()).thenReturn(EvalMode.CANDIDATE_ONLY);
         when(thirdRun.getId()).thenReturn(3L);
         when(thirdRun.mode()).thenReturn(EvalMode.CANDIDATE_ONLY);
-        when(evalRunService.pickQueuedRuns(3)).thenReturn(List.of(firstRun, secondRun, thirdRun));
+        when(evalRunService.claimQueuedRuns(anyInt(), anyString(), any(Duration.class)))
+                .thenReturn(List.of(firstRun, secondRun, thirdRun));
         doThrow(new RuntimeException("boom")).when(evalExecutionService).processRun(2L);
 
         // when
         worker.pollQueuedRuns();
 
         // then
-        verify(evalRunService).pickQueuedRuns(3);
-        verify(evalExecutionService).processRun(1L);
-        verify(evalExecutionService).processRun(2L);
-        verify(evalExecutionService).processRun(3L);
+        verify(evalRunService).claimQueuedRuns(anyInt(), anyString(), any(Duration.class));
+        verify(evalExecutionService, timeout(1000)).processRun(1L);
+        verify(evalExecutionService, timeout(1000)).processRun(2L);
+        verify(evalExecutionService, timeout(1000)).processRun(3L);
+        executor.shutdownNow();
     }
 
     @Test
@@ -63,7 +79,14 @@ class EvalWorkerTest {
         EvalRunService evalRunService = mock(EvalRunService.class);
         EvalExecutionService evalExecutionService = mock(EvalExecutionService.class);
         EvalMetrics evalMetrics = mock(EvalMetrics.class);
-        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>()
+        );
+        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics, executor);
 
         when(evalRunService.recoverStuckRuns(Duration.ofMinutes(45L))).thenReturn(2);
 
@@ -72,6 +95,7 @@ class EvalWorkerTest {
 
         // then
         verify(evalRunService).recoverStuckRuns(Duration.ofMinutes(45L));
+        executor.shutdownNow();
     }
 
     @Test
@@ -84,7 +108,14 @@ class EvalWorkerTest {
         EvalRunService evalRunService = mock(EvalRunService.class);
         EvalExecutionService evalExecutionService = mock(EvalExecutionService.class);
         EvalMetrics evalMetrics = mock(EvalMetrics.class);
-        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>()
+        );
+        EvalWorker worker = new EvalWorker(evalRunService, evalExecutionService, evalProperties, evalMetrics, executor);
 
         doThrow(new RuntimeException("db unavailable"))
                 .when(evalRunService)
@@ -93,5 +124,6 @@ class EvalWorkerTest {
         // when // then
         assertDoesNotThrow(worker::onStartupRecovery);
         verify(evalRunService).recoverStuckRuns(Duration.ofMinutes(30L));
+        executor.shutdownNow();
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #245

## ✨ 작업 내용
- Prompt Eval 실행 경로를 `QUEUED -> CLAIMED -> RUNNING` 상태 전이 기반의 bounded concurrency 구조로 재설계했습니다.
- run-level executor, case-level executor, provider별 concurrency limiter를 추가해 순차 처리 병목을 완화했습니다.
- 후속 재벤치마크를 통해 `max-concurrent-runs` 후보(2/3/4)를 비교했고, 운영 기본값을 `3`으로 상향했습니다.
- 추가 `10건 burst`와 case/provider limiter 재측정 결과를 반영해 최종 운영 기본값을 `run=3 / case=3 / global=9 / openai=6`으로 상향했습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- [Prompt Eval Benchmark 2026-03-18](docs/prompt-eval-benchmark-2026-03-18.md)
- [Prompt Eval Parallelization Plan](docs/prompt-eval-parallelization-plan.md)

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [ ] 리뷰어가 확인해야 할 특이사항이 있나요?

## 실행한 검증 명령
- `./gradlew test --tests "com.llm_ops.demo.eval.service.*" --tests "com.llm_ops.demo.eval.worker.*" --tests "com.llm_ops.demo.eval.domain.*" --tests "com.llm_ops.demo.eval.config.*"`
- `./gradlew test --tests "com.llm_ops.demo.eval.config.EvalPropertiesTest"`
- `POST /api/v1/workspaces/30/prompts/34/eval/runs` smoke: create -> complete (`run 216`)
- `POST /api/v1/workspaces/30/prompts/34/eval/runs/{runId}:cancel` smoke: create -> cancel (`run 217`)
- 재벤치마크: 3건 burst, 5건 burst, `max-concurrent-runs = 2/3/4` 비교
- 재벤치마크: 10건 burst, 기본값(`run=3 / case=2 / global=6 / openai=4`) vs 튜닝값(`run=3 / case=3 / global=9 / openai=6`) 2회 비교

## 리스크 및 롤백 포인트
- 리스크: 현재 운영 기본값은 `run=3 / case=3 / global=9 / openai=6`이며, 다음 병목은 더 큰 burst에서의 OpenAI 429/timeout과 DB/Hikari 경합일 수 있습니다.
- 리스크: 일부 외부 provider 응답 편차에 따라 create HTTP나 개별 run completion 분산은 여전히 존재합니다.
- 롤백: 기본값 롤백은 `application.yml`과 `EvalProperties`의 `case/global/provider` 값을 이전 값(`2/6/4`)으로 되돌리면 되고, 구조 전체 롤백 시에는 `V32__eval_parallel_execution_state.sql` 이후 state/lease 컬럼과 recovery 경로를 함께 확인해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 테스트 케이스 병렬 실행(런/케이스 수준 병렬화) 및 실행 스레드풀 기반 비동기 처리 도입
  * 실행 리스(lease)/클레임 기반 큐잉과 취소 요청(CANCEL_REQUESTED) 상태 지원
  * LLM 제공자별 동시 호출 제한(퍼미트 기반) 추가

* **문서**
  * 병렬화 설계 계획 및 상세 성능 벤치마크 문서 추가

* **구성**
  * 병렬 실행·리스·제한 관련 구성 항목 대폭 확장

* **테스트**
  * 병렬 실행과 구성 동작 검증 단위 테스트 추가

* **기타**
  * 데이터베이스에 실행/리스 추적 필드 및 인덱스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->