### PR TITLE
refactor: fail-fast eval concurrency config (#247)

### DIFF
--- a/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalExecutionConfig.java
@@ -27,7 +27,7 @@ public class EvalExecutionConfig {
 
     @Bean(name = "evalRunExecutor")
     public ThreadPoolExecutor evalRunExecutor() {
-        int maxConcurrentRuns = Math.max(1, evalProperties.getWorker().getMaxConcurrentRuns());
+        int maxConcurrentRuns = evalProperties.getWorker().getMaxConcurrentRuns();
         AtomicInteger sequence = new AtomicInteger(1);
         ThreadFactory threadFactory = runnable -> {
             Thread thread = new Thread(runnable);
@@ -49,7 +49,7 @@ public class EvalExecutionConfig {
 
     @Bean(name = "evalCaseExecutor")
     public ThreadPoolExecutor evalCaseExecutor() {
-        int maxActiveCases = Math.max(1, evalProperties.getExecution().getMaxActiveCasesGlobal());
+        int maxActiveCases = evalProperties.getExecution().getMaxActiveCasesGlobal();
         int queueCapacity = Math.max(maxActiveCases, evalProperties.getExecution().getMaxCaseQueueCapacity());
         AtomicInteger sequence = new AtomicInteger(1);
         ThreadFactory threadFactory = runnable -> {

--- a/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
+++ b/src/main/java/com/llm_ops/demo/eval/config/EvalProperties.java
@@ -1,21 +1,37 @@
 package com.llm_ops.demo.eval.config;
 
 import com.llm_ops.demo.keys.domain.ProviderType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties(prefix = "eval")
+@Validated
 @Getter
 @Setter
 public class EvalProperties {
 
+    @Positive
     private long runTimeoutMinutes = 30L;
+
+    @Valid
     private Judge judge = new Judge();
+
+    @Valid
     private Worker worker = new Worker();
+
+    @Valid
     private Execution execution = new Execution();
+
+    @Valid
     private Runner runner = new Runner();
 
     public long getRunTimeoutMinutes() {
@@ -44,11 +60,19 @@ public class EvalProperties {
     }
 
     public static class Judge {
+        @NotNull
         private ProviderType provider = ProviderType.OPENAI;
+
+        @NotBlank
         private String model = "gpt-4.1-mini";
+
+        @NotNull
         private Double temperature = 0.0;
         private boolean rejudgeOnFail = true;
+
+        @Positive
         private int maxAttempts = 2;
+
         public ProviderType getProvider() {
             return provider;
         }
@@ -93,36 +117,64 @@ public class EvalProperties {
     @Getter
     @Setter
     public static class Worker {
+        @Positive
         private long pollIntervalMs = 3000L;
+
+        @Positive
         private int batchSize = 3;
+
+        @Positive
         private int maxConcurrentRuns = 3;
+
+        @Positive
         private int claimBatchSize = 3;
+
+        @Positive
         private long claimLeaseSeconds = 30L;
+
+        @Positive
         private long runLeaseSeconds = 900L;
     }
 
     @Getter
     @Setter
     public static class Execution {
+        @Positive
         private int maxConcurrentCasesPerRun = 3;
+
+        @Positive
         private int maxActiveCasesGlobal = 9;
+
+        @Positive
         private int maxCaseQueueCapacity = 24;
     }
 
     @Getter
     @Setter
     public static class Runner {
+        @Positive
         private long requestTimeoutMs = 20000L;
+
+        @PositiveOrZero
         private int sameProviderRetryMaxAttempts = 1;
+
+        @PositiveOrZero
         private long sameProviderRetryBackoffMs = 200L;
+
+        @Valid
         private ProviderLimits providerLimits = new ProviderLimits();
     }
 
     @Getter
     @Setter
     public static class ProviderLimits {
+        @Positive
         private int openaiMaxConcurrentCalls = 6;
+
+        @Positive
         private int anthropicMaxConcurrentCalls = 3;
+
+        @Positive
         private int geminiMaxConcurrentCalls = 3;
     }
 }

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalExecutionService.java
@@ -162,7 +162,7 @@ public class EvalExecutionService {
             PromptVersion baselineVersion,
             Duration runLeaseDuration
     ) throws InterruptedException, ExecutionException {
-        int perRunConcurrency = Math.max(1, evalProperties.getExecution().getMaxConcurrentCasesPerRun());
+        int perRunConcurrency = evalProperties.getExecution().getMaxConcurrentCasesPerRun();
         CompletionService<CaseExecutionResult> completionService = new ExecutorCompletionService<>(evalCaseExecutor);
         java.util.Iterator<Long> iterator = queuedCaseIds.iterator();
         int inFlight = 0;

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalJudgeService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalJudgeService.java
@@ -154,8 +154,7 @@ public class EvalJudgeService {
     }
 
     private int resolveMaxAttempts() {
-        int configured = evalProperties.getJudge().getMaxAttempts();
-        return Math.max(1, configured);
+        return evalProperties.getJudge().getMaxAttempts();
     }
 
     private AttemptEvaluation fallbackAttemptEvaluation() {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalProviderConcurrencyLimiter.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalProviderConcurrencyLimiter.java
@@ -16,9 +16,9 @@ public class EvalProviderConcurrencyLimiter {
 
     public EvalProviderConcurrencyLimiter(EvalProperties evalProperties) {
         EvalProperties.ProviderLimits providerLimits = evalProperties.getRunner().getProviderLimits();
-        permits.put(ProviderType.OPENAI, new Semaphore(Math.max(1, providerLimits.getOpenaiMaxConcurrentCalls()), true));
-        permits.put(ProviderType.ANTHROPIC, new Semaphore(Math.max(1, providerLimits.getAnthropicMaxConcurrentCalls()), true));
-        permits.put(ProviderType.GEMINI, new Semaphore(Math.max(1, providerLimits.getGeminiMaxConcurrentCalls()), true));
+        permits.put(ProviderType.OPENAI, new Semaphore(providerLimits.getOpenaiMaxConcurrentCalls(), true));
+        permits.put(ProviderType.ANTHROPIC, new Semaphore(providerLimits.getAnthropicMaxConcurrentCalls(), true));
+        permits.put(ProviderType.GEMINI, new Semaphore(providerLimits.getGeminiMaxConcurrentCalls(), true));
     }
 
     public Permit acquire(ProviderType providerType) {

--- a/src/main/java/com/llm_ops/demo/eval/service/EvalRunService.java
+++ b/src/main/java/com/llm_ops/demo/eval/service/EvalRunService.java
@@ -141,7 +141,7 @@ public class EvalRunService {
         int caseCount = testCases.size();
         int judgeAttemptsMin = 1;
         int judgeAttemptsMax = evalProperties.getJudge().isRejudgeOnFail()
-                ? Math.max(1, evalProperties.getJudge().getMaxAttempts())
+                ? evalProperties.getJudge().getMaxAttempts()
                 : 1;
 
         long generationCallsPerCase = request.mode() == EvalMode.COMPARE_ACTIVE ? 2L : 1L;
@@ -436,7 +436,7 @@ public class EvalRunService {
             return List.of();
         }
 
-        int claimBatchSize = Math.max(1, evalProperties.getWorker().getClaimBatchSize());
+        int claimBatchSize = evalProperties.getWorker().getClaimBatchSize();
         int limit = Math.min(safeCount, claimBatchSize);
         List<Long> runIds = evalRunRepository.findQueuedRunIdsForClaim(EvalRunStatus.QUEUED.name(), limit);
         if (runIds.isEmpty()) {

--- a/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesValidationTest.java
+++ b/src/test/java/com/llm_ops/demo/eval/config/EvalPropertiesValidationTest.java
@@ -1,0 +1,48 @@
+package com.llm_ops.demo.eval.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvalPropertiesValidationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    ValidationAutoConfiguration.class
+            ))
+            .withUserConfiguration(TestConfig.class);
+
+    @ParameterizedTest(name = "{0}={1}")
+    @CsvSource({
+            "eval.worker.max-concurrent-runs, 0",
+            "eval.execution.max-concurrent-cases-per-run, 0",
+            "eval.worker.claim-batch-size, -1",
+            "eval.runner.provider-limits.openai-max-concurrent-calls, 0"
+    })
+    @DisplayName("양수가 필요한 Eval 설정값이 0 이하이면 context 초기화에 실패한다")
+    void 양수가_필요한_Eval_설정값이_0_이하이면_context_초기화에_실패한다(String propertyName, String propertyValue) {
+        // given
+        ApplicationContextRunner runner = contextRunner.withPropertyValues(propertyName + "=" + propertyValue);
+
+        // when // then
+        runner.run(context -> {
+            assertThat(context.getStartupFailure()).isNotNull();
+            assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(BindValidationException.class);
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(EvalProperties.class)
+    static class TestConfig {
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #247

## ✨ 작업 내용
- `EvalProperties`에 `@Validated`와 nested validation 제약을 추가해 Eval 동시성 설정이 0 이하일 때 바인딩 단계에서 실패하도록 변경했습니다.
- Eval 실행 경로에서 동시성 설정에 대한 `Math.max(1, ...)` 보정 로직을 제거해 설정값을 조용히 보정하지 않도록 정리했습니다.
- 잘못된 설정으로 context 초기화가 실패하는 케이스를 검증하는 테스트를 추가했습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- #247

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?

리뷰어 확인사항: 잘못된 Eval 동시성 설정값이 있으면 기존처럼 1로 보정하지 않고 애플리케이션이 부팅 단계에서 실패합니다.

## 실행한 검증 명령
- `./gradlew test --tests "com.llm_ops.demo.eval.config.EvalPropertiesTest" --tests "com.llm_ops.demo.eval.config.EvalPropertiesValidationTest" --tests "com.llm_ops.demo.eval.service.EvalExecutionServiceTest" --tests "com.llm_ops.demo.eval.service.EvalRunServiceTest" --tests "com.llm_ops.demo.eval.service.EvalJudgeServiceTest" --tests "com.llm_ops.demo.eval.service.EvalModelRunnerServiceTest" --tests "com.llm_ops.demo.eval.worker.EvalWorkerTest"`

## 리스크 및 롤백 포인트
- 리스크: 운영 환경에 0 이하의 잘못된 Eval 동시성 설정이 숨어 있었다면 이번 변경 후 서버가 부팅 실패로 즉시 드러납니다.
- 롤백: `7b374d7` 이전 상태로 되돌리면 기존의 조용한 보정 정책으로 복귀합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 속성에 대한 유효성 검사 제약 조건 추가

* **변경 사항**
  * 동시 실행 및 시도 횟수 제한에 대한 최소값 강제 제거
  * 제로 또는 음수 값이 설정되면 스레드 풀 동작에 영향을 미칠 수 있음

* **테스트**
  * 설정 유효성 검사 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->