### PR TITLE
feat: Gateway hard-limit Postgres 예약-정산 도입 (#249)

### DIFF
--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -1,0 +1,784 @@
+# Gateway 예산 Hard-limit 동시성 보장 설계안
+
+작성일: 2026-03-19
+
+이 문서는 Gateway 예산 Hard-limit를 `사후 누적` 방식에서 `Postgres 원자적 예약 + 사후 정산` 방식으로 전환하기 위한 전체 설계 플랜과 ADR을 정리합니다.
+
+## 1) 문서 목적
+
+1. 현재 예산 가드레일 구현의 동시성 한계를 명확히 설명한다.
+2. Redis 없이 PostgreSQL만으로 hard-limit를 일관되게 보장하는 설계 기준을 고정한다.
+3. DB 스키마, 서비스 책임, 게이트웨이 호출 흐름, 복구 전략, 테스트 범위를 한 문서에서 공유한다.
+4. 구현 순서와 롤아웃 단계가 분명한 실행 계획을 제공한다.
+
+## 2) 현재 상태 요약
+
+현재 Gateway 예산 흐름은 아래 순서입니다.
+
+1. 호출 전 `BudgetGuardrailService`가 현재 월 사용량을 조회한다.
+2. Workspace는 soft-limit 초과 시 `DEGRADE`를 결정한다.
+3. Provider credential은 hard-limit 초과 시 `BLOCK`를 결정한다.
+4. LLM 호출이 성공하면 `BudgetUsageService.recordUsage()`가 실제 비용을 월 사용량 테이블에 누적한다.
+
+현재 구조의 장점은 단순하다는 점입니다. 하지만 hard-limit 동시성 보장 관점에서는 아래 한계가 있습니다.
+
+1. 여러 요청이 동시에 같은 월 사용량을 읽고 모두 "아직 limit 미만"으로 판단할 수 있다.
+2. 호출이 끝난 뒤에만 비용을 반영하므로 in-flight 요청은 예산 판단에서 보이지 않는다.
+3. 기존 `budget_monthly_usage` row 갱신은 원자적 증가 SQL이 아니라 JPA entity 누적이어서 lost update 가능성이 있다.
+4. strict hard-limit를 설명해야 하는 상황에서 현재 구조는 방어가 어렵다.
+
+한 줄 요약:
+
+`조회 -> 호출 -> 사후 누적`은 soft guardrail에는 쓸 수 있지만, 동시 요청 환경의 hard-limit 보장 방식으로는 부족하다.
+
+## 3) 목표와 비목표
+
+### 목표
+
+1. 같은 scope에 여러 요청이 동시에 들어와도 hard-limit 초과 판단이 일관되게 동작한다.
+2. LLM 호출 시간 동안 DB 트랜잭션, row lock, connection을 붙잡지 않는다.
+3. 요청 성공 시 실제 비용만 확정 반영하고, 남은 예약액은 반환한다.
+4. 요청 실패, timeout, 프로세스 중단 시에도 예약 누수를 복구할 수 있다.
+5. 운영자가 reservation 상태를 로그와 메트릭으로 추적할 수 있다.
+
+### 비목표
+
+1. 예산 정책 UI/UX 개편
+2. Redis 도입
+3. 모델 단가 DB 이관
+4. 모든 provider 과금 규칙의 완전한 실시간 정밀 재현
+5. Playground 비용 경로까지 이번에 동시에 전환
+
+## 4) 핵심 결정 요약
+
+이번 설계의 핵심은 hard-limit를 아래 두 단계로 분리하는 것입니다.
+
+1. 예약
+- 요청 시작 시 최대 가능 비용 상한을 계산한다.
+- Postgres에서 조건부 update로 해당 금액을 먼저 예약한다.
+- 예약 성공한 요청만 LLM 호출을 진행한다.
+
+2. 정산
+- 호출 완료 후 실제 비용을 계산한다.
+- 예약액 중 실제 사용액만 `spent`로 확정한다.
+- 남은 금액은 반환한다.
+
+이 방식은 비관적 락처럼 LLM 호출 시간 동안 DB를 붙잡지 않으면서도, in-flight 요청까지 포함한 hard-limit 판단이 가능하다는 점에서 현재 스택에 가장 적합하다.
+
+## 5) 용어 정의
+
+1. `spent`
+- 이미 확정된 실제 사용 금액
+- 기존 `budget_monthly_usage.cost_usd`가 담당
+
+2. `reserved`
+- 아직 호출이 끝나지 않았지만 hard-limit 판단을 위해 선점한 금액
+- 새 컬럼 `reserved_cost_usd`가 담당
+
+3. `reservation`
+- 요청 단위의 예약 레코드
+- reservation amount, 상태, 만료 시각, 정산 결과를 기록
+
+4. `effective max tokens`
+- prompt version의 `modelConfig.maxTokens`와 budget degrade override를 반영한 최종 출력 토큰 상한
+
+5. `projected spend`
+- `spent + reserved`
+- soft-limit 평가와 hard-limit 조건식의 기준
+
+## 6) 목표 아키텍처
+
+요청 1건의 이상적인 흐름은 아래와 같습니다.
+
+1. 인증 및 프롬프트 해석
+2. Workspace soft-limit 평가
+3. effective model / effective max tokens 결정
+4. 최대 가능 비용 상한 계산
+5. Provider credential hard-limit 예약 시도
+6. 필요 시 workspace hard-limit 예약 시도
+7. 예약 성공 시 provider 호출
+8. 성공하면 settle
+9. 실패하면 release
+10. timeout 또는 프로세스 중단으로 누락된 reservation은 sweeper가 expire
+
+핵심 원칙은 다음과 같습니다.
+
+1. DB는 `예약 승인/거절`만 짧게 결정한다.
+2. LLM 호출은 예약 후 DB와 분리된 상태에서 수행한다.
+3. 정산과 반환은 idempotent해야 한다.
+4. failover는 secondary 기준으로 다시 예약하는 독립 경로로 본다.
+
+## 7) 데이터 모델 설계
+
+### 7-1) `budget_monthly_usage` 확장
+
+기존 테이블은 유지하되 아래 컬럼을 추가합니다.
+
+1. `reserved_cost_usd NUMERIC(18, 8) NOT NULL DEFAULT 0`
+
+기존 컬럼 의미는 아래처럼 고정합니다.
+
+1. `cost_usd`
+- 확정 사용 금액
+
+2. `total_tokens`
+- 확정 사용 토큰
+
+3. `request_count`
+- 확정 완료된 요청 수
+
+4. `reserved_cost_usd`
+- 아직 정산되지 않은 in-flight 예약 총액
+
+### 7-2) `budget_reservations` 신규 테이블
+
+요청 단위 reservation 추적용 테이블을 추가합니다.
+
+예상 컬럼:
+
+1. `id BIGSERIAL PRIMARY KEY`
+2. `request_log_id UUID NULL`
+3. `trace_id VARCHAR(64) NOT NULL`
+4. `scope_type VARCHAR(32) NOT NULL`
+5. `scope_id BIGINT NOT NULL`
+6. `year_month INTEGER NOT NULL`
+7. `provider VARCHAR(32) NULL`
+8. `model VARCHAR(128) NULL`
+9. `reserved_cost_usd NUMERIC(18, 8) NOT NULL`
+10. `settled_cost_usd NUMERIC(18, 8) NULL`
+11. `reserved_input_tokens INTEGER NULL`
+12. `reserved_output_tokens INTEGER NULL`
+13. `status VARCHAR(32) NOT NULL`
+14. `release_reason VARCHAR(64) NULL`
+15. `expires_at TIMESTAMPTZ NOT NULL`
+16. `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+17. `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+
+권장 unique 제약:
+
+1. `uq_budget_reservations_trace_scope (trace_id, scope_type, scope_id)`
+
+이 unique key는 같은 요청이 같은 scope에 대해 예약을 중복 생성하지 않도록 방지합니다.
+
+### 7-3) reservation 상태
+
+1. `RESERVED`
+- 예약 성공, 아직 호출/정산 미완료
+
+2. `SETTLED`
+- 실제 사용액 확정 반영 완료
+
+3. `RELEASED`
+- 실패 또는 정책상 취소되어 예약 전액 반환 완료
+
+4. `EXPIRED`
+- TTL 경과 후 백그라운드 복구 작업으로 반환 완료
+
+## 8) 예약 금액 계산 정책
+
+예약은 평균 예상치가 아니라 최대 가능 비용 상한을 기준으로 해야 합니다.
+
+### 8-1) 입력 토큰 상한
+
+입력 토큰 상한은 아래를 합쳐 계산합니다.
+
+1. system prompt 렌더링 결과
+2. user prompt 렌더링 결과
+3. RAG context가 활성화되면 최종 주입된 context
+4. provider별 message framing 오버헤드 safety margin
+
+토큰 계산은 이미 의존성에 포함된 `jtokkit`을 사용합니다.
+
+정책:
+
+1. 기본 tokenizer는 `CL100K_BASE`를 사용한다.
+2. provider별 tokenizer 차이는 우선 안전계수로 흡수한다.
+3. 1차 rollout에서는 `input_tokens * 1.10` 정도의 safety multiplier를 둔다.
+
+### 8-2) 출력 토큰 상한
+
+출력 토큰은 실제 응답 전에는 알 수 없으므로 아래 순서로 상한을 잡습니다.
+
+1. budget degrade override의 `maxOutputTokens`
+2. prompt version `modelConfig.maxTokens`
+3. 시스템 기본값
+
+기본값 제안:
+
+1. `2048`
+
+이 값은 설정으로 뺄 수 있도록 한다.
+
+### 8-3) 비용 계산식
+
+비용 계산은 기존 `ModelPricing`을 재사용합니다.
+
+`reserveAmount = cost(model, estimatedInputTokensUpperBound, effectiveMaxTokens)`
+
+정책:
+
+1. 모델 단가를 알 수 있으면 해당 단가로 계산한다.
+2. 모델 단가를 모르면 hard-limit는 fail-closed 한다.
+3. 단가 미등록 모델은 `GW-GW-POLICY_BLOCKED` 또는 `BUDGET_PRICING_UNAVAILABLE` 성격의 내부 사유로 차단한다.
+
+## 9) 원자적 예약 알고리즘
+
+### 9-1) usage row 보장
+
+월별 usage row가 없을 수 있으므로 먼저 아래와 같이 row를 보장합니다.
+
+```sql
+INSERT INTO budget_monthly_usage (
+    scope_type, scope_id, year_month, cost_usd, total_tokens, request_count, reserved_cost_usd
+) VALUES (
+    :scopeType, :scopeId, :yearMonth, 0, 0, 0, 0
+)
+ON CONFLICT (scope_type, scope_id, year_month) DO NOTHING;
+```
+
+### 9-2) 예약 승인
+
+예약 승인 핵심 쿼리는 아래와 같습니다.
+
+```sql
+UPDATE budget_monthly_usage u
+SET reserved_cost_usd = u.reserved_cost_usd + :reserveAmount
+WHERE u.scope_type = :scopeType
+  AND u.scope_id = :scopeId
+  AND u.year_month = :yearMonth
+  AND u.cost_usd + u.reserved_cost_usd + :reserveAmount <= :monthLimitUsd;
+```
+
+결과 해석:
+
+1. update count = 1
+- 예약 성공
+
+2. update count = 0
+- 예산 초과로 예약 실패
+
+이 쿼리의 장점은 조건 검사와 증가가 DB 안에서 한 번에 일어나므로, 동시 요청에서도 race condition 없이 승인/거절이 결정된다는 점입니다.
+
+### 9-3) reservation 레코드 생성
+
+usage row 예약 성공 후에 `budget_reservations`에 `RESERVED` 상태를 INSERT 합니다.
+
+실패 시 처리:
+
+1. reservation INSERT 실패 시 같은 트랜잭션 안에서 `reserved_cost_usd`를 되돌린다.
+2. trace 중복이면 기존 reservation 상태를 조회해 idempotent 처리한다.
+
+## 10) 정산 및 반환 알고리즘
+
+### 10-1) 성공 시 settle
+
+성공 시에는 reservation을 읽고 아래 순서로 처리합니다.
+
+1. `actualCostUsd` 계산
+2. `reserved_cost_usd -= reservedAmount`
+3. `cost_usd += actualCostUsd`
+4. `total_tokens += actualTokens`
+5. `request_count += 1`
+6. reservation status를 `SETTLED`로 변경
+7. `settled_cost_usd = actualCostUsd` 저장
+
+핵심 원칙:
+
+1. 정산은 reservation row 기준으로 한 번만 일어나야 한다.
+2. 이미 `SETTLED`, `RELEASED`, `EXPIRED` 상태면 중복 정산하지 않는다.
+
+### 10-2) 실패 시 release
+
+실패 시에는 아래 순서로 처리합니다.
+
+1. `reserved_cost_usd -= reservedAmount`
+2. reservation status를 `RELEASED`로 변경
+3. `release_reason` 저장
+
+실패 사유 예시:
+
+1. `PROVIDER_TIMEOUT`
+2. `PROVIDER_ERROR`
+3. `FAILOVER_RETRY`
+4. `REQUEST_CANCELLED`
+5. `PRIMARY_ROUTE_FAILED`
+
+### 10-3) expire sweeper
+
+reservation이 `RESERVED` 상태인데 `expires_at < now()`이면 stale reservation으로 판단합니다.
+
+백그라운드 작업은 아래를 수행합니다.
+
+1. 만료 대상 reservation batch 조회
+2. usage row의 `reserved_cost_usd` 반환
+3. reservation status를 `EXPIRED`로 변경
+4. metric 및 warn log 기록
+
+TTL 기준:
+
+1. `gateway.reliability.request-timeout-ms + buffer`
+2. 기본 buffer는 10초 제안
+
+## 11) Gateway 호출 흐름 통합
+
+### 11-1) primary 성공 경로
+
+1. workspace soft-limit 평가
+2. effective model / max tokens 결정
+3. provider credential 예산 예약
+4. workspace hard-limit 예약
+5. provider call
+6. 실제 비용 계산
+7. provider reservation settle
+8. workspace reservation settle
+9. success log 기록
+
+### 11-2) primary blocked 경로
+
+1. primary provider credential reservation 실패
+2. secondary 경로가 없으면 즉시 budget exceeded 반환
+3. secondary가 있으면 secondary 기준으로 새 예약 시도
+4. secondary도 예약 실패하면 blocked 반환
+
+### 11-3) primary 실패 후 failover 경로
+
+1. primary 예약 성공
+2. primary 호출 실패
+3. primary reservation release
+4. secondary provider 기준으로 새 상한 계산
+5. secondary reservation 시도
+6. 성공 시 secondary 호출
+7. 성공하면 secondary settle, 실패하면 secondary release
+
+이 경로를 쓰는 이유:
+
+1. primary와 secondary는 모델 단가, output 상한, provider budget scope가 다를 수 있다.
+2. failover는 "같은 예약을 이어서 사용"하는 문제가 아니라 "새 경로에 대한 새 예약"으로 보는 편이 단순하다.
+
+## 12) Soft-limit와의 상호작용
+
+soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
+
+따라서 평가 기준을 아래로 바꿉니다.
+
+1. 기존: `cost_usd >= soft_limit`
+2. 변경: `cost_usd + reserved_cost_usd >= soft_limit`
+
+이렇게 하면 이미 진행 중인 요청까지 반영해 더 일찍 degrade가 걸릴 수 있습니다.
+
+정책상 soft-limit는 약간 보수적으로 반응해도 문제가 적기 때문에, projected spend 기준이 더 운영 친화적입니다.
+
+## 13) 트랜잭션 경계
+
+이번 설계에서 가장 중요한 원칙은 "짧은 트랜잭션"입니다.
+
+### 트랜잭션 1: reserve
+
+포함:
+
+1. usage row 보장
+2. 조건부 reserve update
+3. reservation row insert
+
+비포함:
+
+1. provider call
+
+### 트랜잭션 2: settle
+
+포함:
+
+1. reservation 상태 검증
+2. reserved 감소
+3. spent 증가
+4. tokens/request_count 증가
+5. reservation 상태 변경
+
+### 트랜잭션 3: release
+
+포함:
+
+1. reservation 상태 검증
+2. reserved 감소
+3. reservation 상태 변경
+
+즉 LLM 호출 구간은 어떤 트랜잭션 안에도 포함되지 않습니다.
+
+## 14) 서비스 책임 분리안
+
+### `BudgetReservationEstimator`
+
+책임:
+
+1. input token 상한 계산
+2. output token 상한 계산
+3. 모델 단가 기반 reserve amount 계산
+
+### `BudgetReservationService`
+
+책임:
+
+1. reserve
+2. settle
+3. release
+4. expire stale reservations
+
+### `BudgetGuardrailService`
+
+책임:
+
+1. workspace soft-limit degrade 의사결정
+2. projected spend 기반 정책 평가
+
+### `GatewayChatService`
+
+책임:
+
+1. reservation 시점 orchestration
+2. primary/secondary 경로 전환
+3. success/failure에 따른 settle/release 호출
+
+## 15) 단계별 구현 플랜
+
+### Epic 21. Gateway 예산 Hard-limit 동시성 보장
+
+### [x] E21-1 현행 예산 경로 분석 및 ADR 고정
+
+- 목표: 현재 hard-limit 동작과 동시성 gap을 문서로 확정한다.
+- 범위: Gateway, budget, pricing, request log 경로 분석.
+- 완료 조건: 이 문서와 ADR이 팀 합의본으로 사용된다.
+- 검증: 설계 리뷰.
+
+### [x] E21-2 DB 스키마 확장
+
+- 목표: reservation을 저장할 최소 스키마를 도입한다.
+- 범위: `budget_monthly_usage` 컬럼 추가, `budget_reservations` 신규 테이블, 인덱스/unique 제약.
+- 완료 조건: migration이 로컬/테스트 DB에 정상 적용된다.
+- 검증: Flyway migration 실행.
+
+### [ ] E21-3 Repository와 원자적 SQL 도입
+
+- 목표: reserve/settle/release를 native query로 구현한다.
+- 범위: usage upsert, reserve update, settle update, release update, stale reservation 조회.
+- 완료 조건: lost update 없이 row count 기반 예약 결과를 얻는다.
+- 검증: repository 단위 테스트.
+
+### [ ] E21-4 최대 비용 상한 계산기 도입
+
+- 목표: 예약액을 deterministic하게 계산한다.
+- 범위: jtokkit 기반 token estimate, effective max tokens, unknown model 정책.
+- 완료 조건: reserve amount가 provider/model별로 재현 가능하다.
+- 검증: estimator 단위 테스트.
+
+### [ ] E21-5 Gateway 흐름 통합
+
+- 목표: provider call 전에 reserve, 종료 후 settle/release가 되도록 바꾼다.
+- 범위: primary, failover, blocked, timeout, unexpected exception 경로.
+- 완료 조건: 예약 성공한 요청만 provider call을 수행한다.
+- 검증: `GatewayChatServiceUnitTest`.
+
+### [ ] E21-6 TTL 복구 작업 도입
+
+- 목표: orphan reservation을 자동 복구한다.
+- 범위: sweeper job, expire 정책, 메트릭 추가.
+- 완료 조건: stale reservation이 일정 시간 후 반환된다.
+- 검증: expire recovery 테스트.
+
+### [ ] E21-7 관측성 보강
+
+- 목표: 운영자가 reservation 상태를 관측할 수 있게 한다.
+- 범위: metrics, log fields, fail reason 정리.
+- 완료 조건: reserve/settle/release/expire 이벤트가 메트릭으로 보인다.
+- 검증: actuator metrics 확인.
+
+### [ ] E21-8 동시성 테스트 확대
+
+- 목표: hard-limit 일관성을 자동 테스트로 고정한다.
+- 범위: repository concurrency test, integration test, failover + reservation test.
+- 완료 조건: 같은 scope에서 허용 수만 통과하고 나머지는 차단된다.
+- 검증: targeted gradle tests.
+
+### [ ] E21-9 문서 동기화
+
+- 목표: 구현 변경이 제품/DB/API 문서에 반영되게 한다.
+- 범위: `.ai/features.md`, `.ai/api-implemented.md`, `.ai/database.md`, `.ai/tasklist.md`.
+- 완료 조건: hard-limit 설명이 `사전 예약 + 사후 정산` 기준으로 정렬된다.
+- 검증: 문서 리뷰.
+
+## 16) 테스트 전략
+
+### 16-1) Repository 단위 테스트
+
+1. reserve 성공
+2. reserve 실패
+3. 동시에 2건 reserve 시 1건만 성공
+4. settle 시 reserved 감소 + spent 증가
+5. release 시 reserved 감소
+6. 이미 정산된 reservation에 중복 settle 호출 시 무해함
+
+### 16-2) Service 테스트
+
+1. estimator가 effective max tokens override를 반영하는지
+2. unknown model이 fail-closed 되는지
+3. soft-limit가 `spent + reserved` 기준으로 degrade 되는지
+4. expire sweeper가 stale reservation만 처리하는지
+
+### 16-3) Gateway 테스트
+
+1. hard-limit 초과면 provider call 0회
+2. primary blocked 시 secondary reservation 성공이면 failover 진행
+3. primary 실패 후 secondary 재예약 경로
+4. timeout 시 release 수행
+5. unexpected exception 시 release 누락이 없는지
+
+### 16-4) 동시성 통합 테스트
+
+핵심 회귀 시나리오:
+
+1. 남은 예산이 요청 1건분일 때 동시 2요청
+2. 결과: 정확히 1건만 reserve 성공
+3. 다른 1건은 budget blocked
+
+이 테스트가 이번 변경의 핵심 acceptance criteria다.
+
+## 17) 운영 메트릭 및 로그
+
+추가 메트릭 제안:
+
+1. `gateway_budget_reserve_total`
+2. `gateway_budget_reserve_failed_total`
+3. `gateway_budget_settle_total`
+4. `gateway_budget_release_total`
+5. `gateway_budget_reservation_expired_total`
+6. `gateway_budget_reserved_usd`
+
+추가 로그 필드 제안:
+
+1. `budget_reserved_usd`
+2. `budget_settled_usd`
+3. `budget_reservation_status`
+4. `budget_reservation_release_reason`
+
+운영상 확인하고 싶은 질문은 아래와 같습니다.
+
+1. budget blocked가 실제 정책 차단 때문인지 pricing 미상 때문인지
+2. reservation 누수가 없는지
+3. failover가 budget 때문인지 provider 장애 때문인지
+4. 특정 provider/model이 과도하게 큰 reserve amount를 유발하는지
+
+## 18) 리스크와 대응
+
+### 리스크 1. 상한 계산이 너무 보수적일 수 있음
+
+영향:
+
+1. 실제보다 큰 금액이 오래 예약되어 throughput이 떨어질 수 있다.
+
+대응:
+
+1. 초기에는 안전 우선으로 보수적 계산
+2. 실제 settle 비용과 reserve 비용 차이를 메트릭으로 모니터링
+3. 이후 모델별 safety margin 튜닝
+
+### 리스크 2. provider별 과금 규칙 차이
+
+영향:
+
+1. 계산 오차가 생길 수 있다.
+
+대응:
+
+1. 1차는 현재 `ModelPricing` 기준으로 통일
+2. 오차가 큰 provider는 개별 estimation policy로 분리
+
+### 리스크 3. reservation orphan
+
+영향:
+
+1. reserved 금액이 반환되지 않으면 false block 발생
+
+대응:
+
+1. TTL + sweeper
+2. idempotent release/settle
+3. warning metric과 운영 알람
+
+### 리스크 4. migration 후 코드 미반영 상태
+
+영향:
+
+1. `reserved_cost_usd` 추가만 되고 예약 로직이 미완성이면 문서와 동작이 어긋날 수 있다.
+
+대응:
+
+1. feature toggle 또는 순차 배포
+2. migration과 service wiring을 같은 배포 단위로 묶기
+
+## 19) 비관적 락과 Redis를 채택하지 않은 이유
+
+### 비관적 락 비채택 이유
+
+1. `SELECT ... FOR UPDATE`는 직관적이지만 LLM 호출처럼 긴 외부 I/O와 결합되면 위험하다.
+2. 트랜잭션/커넥션 유지 시간이 길어져 connection pool exhaustion 가능성이 커진다.
+3. tail latency가 커지고 장애 시 대기가 연쇄적으로 늘어날 수 있다.
+
+### Redis 비채택 이유
+
+1. 현재 인프라에 Redis가 없다.
+2. 예산 정책, usage, request log를 같은 저장소에서 추적하는 편이 운영상 단순하다.
+3. Redis + Postgres 이중 정합성 문제까지 함께 관리할 필요가 생긴다.
+4. 현재 규모에서는 Postgres 원자적 예약-정산이 더 실용적이다.
+
+## 20) 구현 대상 파일 초안
+
+예상 변경 파일:
+
+1. `src/main/resources/db/migration/V__...sql`
+2. `src/main/java/com/llm_ops/demo/budget/domain/BudgetMonthlyUsage.java`
+3. `src/main/java/com/llm_ops/demo/budget/domain/BudgetReservation.java`
+4. `src/main/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepository.java`
+5. `src/main/java/com/llm_ops/demo/budget/repository/BudgetReservationRepository.java`
+6. `src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java`
+7. `src/main/java/com/llm_ops/demo/budget/service/BudgetReservationEstimator.java`
+8. `src/main/java/com/llm_ops/demo/budget/service/BudgetGuardrailService.java`
+9. `src/main/java/com/llm_ops/demo/gateway/service/GatewayChatService.java`
+10. `src/main/java/com/llm_ops/demo/gateway/service/GatewayMetrics.java`
+11. 관련 단위/통합 테스트
+
+## 21) 구현 후 검증 명령 초안
+
+```bash
+./gradlew test \
+  --tests "com.llm_ops.demo.budget.*" \
+  --tests "com.llm_ops.demo.gateway.service.GatewayChatServiceUnitTest"
+
+./gradlew clean test
+```
+
+필요 시 로컬 부하/동시성 검증은 별도 시나리오로 추가합니다.
+
+## 22) ADR
+
+### 제목
+
+Postgres 원자적 예약-정산 기반 Gateway 예산 Hard-limit 동시성 제어 도입
+
+### 상태
+
+Proposed
+
+### 문맥
+
+현재 Gateway hard-limit는 호출 전 월 누적 비용을 조회하고, 호출 성공 후 실제 비용을 누적하는 구조다. 이 방식은 구현이 단순하지만 동시 요청 환경에서 여러 요청이 동일한 사용량을 읽고 함께 통과할 수 있어 hard-limit 일관성이 깨질 수 있다. 또한 기존 월 사용량 row 갱신은 atomic increment 쿼리가 아니라 entity 누적 방식이라 lost update 위험이 존재한다.
+
+우리 시스템은 PostgreSQL을 이미 사용하고 있고 Redis는 도입되어 있지 않다. LLM 호출은 느린 외부 I/O이며 응답 시간이 길 수 있으므로, 비관적 락을 호출 구간 전체에 유지하는 방식은 DB 커넥션 풀 고갈과 대기 시간 증가를 유발할 가능성이 높다. 운영 가시성과 복구 용이성도 중요한 요구사항이므로, 예산 상태와 요청 로그를 같은 저장소 안에서 일관되게 추적할 수 있는 방식이 필요하다.
+
+### 결정
+
+Gateway hard-limit는 PostgreSQL 기반 원자적 예약-정산 방식으로 구현한다.
+
+1. 요청 시작 시 최대 가능 비용 상한을 계산한다.
+2. 짧은 트랜잭션에서 `budget_monthly_usage.reserved_cost_usd`를 조건부 증가시켜 예약한다.
+3. 예약 성공한 요청만 provider call을 수행한다.
+4. 호출 종료 후 실제 비용을 `cost_usd`에 반영하고, 남은 예약액은 반환한다.
+5. 실패/timeout/예외 시 예약을 반환한다.
+6. 요청 중단으로 누락된 reservation은 TTL 기반 sweeper가 복구한다.
+
+### 결정 상세
+
+1. hard-limit 승인 조건은 `spent + reserved + reserveAmount <= monthLimit`로 정의한다.
+2. soft-limit degrade는 `spent + reserved` 기준으로 평가한다.
+3. 예약 금액은 평균 예상치가 아니라 최대 가능 비용 상한으로 계산한다.
+4. 모델 단가를 모르면 hard-limit는 fail-closed 한다.
+5. primary와 secondary failover는 서로 다른 provider/model 예산 경로로 보며, failover 시 새 reservation을 생성한다.
+
+### 장점
+
+1. Redis 없이도 strong-enough hard-limit 일관성을 확보할 수 있다.
+2. LLM 호출 시간 동안 트랜잭션/락/커넥션을 유지하지 않는다.
+3. 예산, reservation, 로그를 PostgreSQL에서 함께 추적할 수 있다.
+4. 운영 장애 분석과 감사 추적이 단순해진다.
+
+### 단점
+
+1. 도메인과 스키마가 복잡해진다.
+2. stale reservation 복구와 idempotent 정산 로직이 필요하다.
+3. 상한 계산이 보수적이면 예산이 과하게 묶일 수 있다.
+4. provider 과금 체계를 100% 실시간으로 재현하지는 못한다.
+
+### 검토한 대안
+
+#### 대안 1. 현행 사후 누적 유지
+
+장점:
+
+1. 구현이 단순하다.
+
+단점:
+
+1. 동시 요청 hard-limit 일관성을 보장하지 못한다.
+
+결론:
+
+기각
+
+#### 대안 2. DB 비관적 락
+
+장점:
+
+1. 구현 개념이 직관적이다.
+
+단점:
+
+1. LLM 호출처럼 느린 외부 I/O와 결합되면 커넥션 풀 고갈 위험이 크다.
+2. 대기 시간이 길어지고 tail latency가 악화된다.
+
+결론:
+
+기각
+
+#### 대안 3. DB 낙관적 락
+
+장점:
+
+1. 락을 오래 쥐지 않는다.
+
+단점:
+
+1. hot row에서 충돌과 재시도가 증가할 수 있다.
+2. 예약 개념을 명확하게 표현하기 어렵다.
+
+결론:
+
+주 방식으로 채택하지 않음
+
+#### 대안 4. Redis 예약-정산
+
+장점:
+
+1. 높은 처리량과 빠른 원자 연산
+
+단점:
+
+1. 새 인프라가 필요하다.
+2. Redis와 Postgres 간 정합성 관리가 추가된다.
+
+결론:
+
+현 시점 보류
+
+### 결과
+
+1. 구현 복잡도는 증가하지만, 현재 스택과 운영 요구사항을 고려하면 가장 균형이 좋다.
+2. 1차 적용은 provider credential hard-limit에 우선 도입한다.
+3. 안정화 후 workspace hard-limit까지 동일 엔진으로 확장한다.
+
+## 23) 팀 공유용 요약
+
+```text
+Gateway hard-limit는 단순 조회 후 사후 누적 방식으로는 동시 요청 일관성을 보장하기 어렵습니다.
+이를 해결하기 위해 Postgres에서 요청 시작 시 최대 비용 상한을 먼저 예약하고,
+호출 종료 후 실제 비용만 확정 반영하는 예약-정산 구조로 전환합니다.
+이 방식은 Redis 없이도 hard-limit를 더 강하게 보장하면서,
+LLM 호출 동안 DB 락/커넥션을 오래 잡지 않아 운영 안정성도 유지할 수 있습니다.
+```

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -193,7 +193,7 @@
 
 1. 기본 tokenizer는 `CL100K_BASE`를 사용한다.
 2. provider별 tokenizer 차이는 우선 안전계수로 흡수한다.
-3. 1차 rollout에서는 `input_tokens * 1.10` 정도의 safety multiplier를 둔다.
+3. 1차 rollout에서는 `budget.reservation.input-token-safety-multiplier` 기본값 `1.10`을 사용한다.
 
 ### 8-2) 출력 토큰 상한
 
@@ -207,7 +207,7 @@
 
 1. `2048`
 
-이 값은 설정으로 뺄 수 있도록 한다.
+현재 구현은 `budget.reservation.default-max-output-tokens` 설정으로 이 값을 외부화한다.
 
 ### 8-3) 비용 계산식
 
@@ -471,12 +471,12 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: lost update 없이 row count 기반 예약 결과를 얻는다.
 - 검증: `BudgetMonthlyUsageRepositoryTest`, `BudgetReservationRepositoryTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
-### [ ] E21-4 최대 비용 상한 계산기 도입
+### [x] E21-4 최대 비용 상한 계산기 도입
 
 - 목표: 예약액을 deterministic하게 계산한다.
 - 범위: jtokkit 기반 token estimate, effective max tokens, unknown model 정책.
 - 완료 조건: reserve amount가 provider/model별로 재현 가능하다.
-- 검증: estimator 단위 테스트.
+- 검증: `BudgetReservationEstimatorTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
 ### [ ] E21-5 Gateway 흐름 통합
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -48,6 +48,7 @@
 3. 모델 단가 DB 이관
 4. 모든 provider 과금 규칙의 완전한 실시간 정밀 재현
 5. Playground 비용 경로까지 이번에 동시에 전환
+6. Workspace soft-limit에 hard-limit 수준의 strict concurrency 보장 부여
 
 ## 4) 핵심 결정 요약
 
@@ -95,11 +96,12 @@
 3. effective model / effective max tokens 결정
 4. 최대 가능 비용 상한 계산
 5. Provider credential hard-limit 예약 시도
-6. 필요 시 workspace hard-limit 예약 시도
-7. 예약 성공 시 provider 호출
-8. 성공하면 settle
-9. 실패하면 release
-10. timeout 또는 프로세스 중단으로 누락된 reservation은 sweeper가 expire
+6. 예약 성공 시 provider 호출
+7. 성공하면 settle
+8. 실패하면 release
+9. timeout 또는 프로세스 중단으로 누락된 reservation은 sweeper가 expire
+
+현재 rollout 기준으로 strict reservation 대상은 `PROVIDER_CREDENTIAL` scope만 포함합니다. `WORKSPACE`는 soft-limit `DEGRADE` 판단용 scope이며, 동시 in-flight 요청까지 hard-limit 수준으로 선점하지는 않습니다.
 
 핵심 원칙은 다음과 같습니다.
 
@@ -334,12 +336,10 @@ TTL 기준:
 1. workspace soft-limit 평가
 2. effective model / max tokens 결정
 3. provider credential 예산 예약
-4. workspace hard-limit 예약
-5. provider call
-6. 실제 비용 계산
-7. provider reservation settle
-8. workspace reservation settle
-9. success log 기록
+4. provider call
+5. 실제 비용 계산
+6. provider reservation settle
+7. success log 기록
 
 ### 11-2) primary blocked 경로
 
@@ -375,6 +375,8 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 이렇게 하면 이미 진행 중인 요청까지 반영해 더 일찍 degrade가 걸릴 수 있습니다.
 
 정책상 soft-limit는 약간 보수적으로 반응해도 문제가 적기 때문에, projected spend 기준이 더 운영 친화적입니다.
+
+다만 현재 구현과 rollout 범위에서는 reservation을 `PROVIDER_CREDENTIAL` scope에만 생성합니다. 따라서 `WORKSPACE` soft-limit는 hard-limit처럼 strict consistency를 보장하는 장치가 아니라, 운영상 더 이른 `DEGRADE`를 유도하는 advisory 신호로 해석해야 합니다. 동시에 여러 workspace 요청이 들어오면 일부 in-flight 요청은 soft-limit 평가 시점에 완전히 반영되지 않을 수 있으며, 이것은 현재 정책상 허용된 trade-off입니다.
 
 ## 13) 트랜잭션 경계
 
@@ -701,7 +703,7 @@ Gateway hard-limit는 PostgreSQL 기반 원자적 예약-정산 방식으로 구
 ### 결정 상세
 
 1. hard-limit 승인 조건은 `spent + reserved + reserveAmount <= monthLimit`로 정의한다.
-2. soft-limit degrade는 `spent + reserved` 기준으로 평가한다.
+2. soft-limit degrade는 `spent + reserved` 기준을 우선 사용하되, 현재 rollout에서는 `PROVIDER_CREDENTIAL` reservation만 strict하게 생성하므로 `WORKSPACE` soft-limit는 advisory/best-effort guardrail로 본다.
 3. 예약 금액은 평균 예상치가 아니라 최대 가능 비용 상한으로 계산한다.
 4. 모델 단가를 모르면 hard-limit는 fail-closed 한다.
 5. primary와 secondary failover는 서로 다른 provider/model 예산 경로로 보며, failover 시 새 reservation을 생성한다.
@@ -785,7 +787,8 @@ Gateway hard-limit는 PostgreSQL 기반 원자적 예약-정산 방식으로 구
 
 1. 구현 복잡도는 증가하지만, 현재 스택과 운영 요구사항을 고려하면 가장 균형이 좋다.
 2. 1차 적용은 provider credential hard-limit에 우선 도입한다.
-3. 안정화 후 workspace hard-limit까지 동일 엔진으로 확장한다.
+3. workspace soft-limit는 advisory/best-effort guardrail로 유지하며, hard-limit 수준의 strict reservation은 현재 범위에 포함하지 않는다.
+4. 필요 시 안정화 이후 workspace hard-limit를 별도 정책으로 추가하고 동일 reservation 엔진을 재사용할 수 있다.
 
 ## 23) 팀 공유용 요약
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -485,12 +485,12 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: 예약 성공한 요청만 provider call을 수행한다.
 - 검증: `GatewayChatServiceUnitTest`, `BudgetReservationEstimatorTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
-### [ ] E21-6 TTL 복구 작업 도입
+### [x] E21-6 TTL 복구 작업 도입
 
 - 목표: orphan reservation을 자동 복구한다.
 - 범위: sweeper job, expire 정책, 메트릭 추가.
 - 완료 조건: stale reservation이 일정 시간 후 반환된다.
-- 검증: expire recovery 테스트.
+- 검증: `BudgetReservationServiceTest`, `BudgetReservationRecoveryJobTest`, `GatewayChatServiceUnitTest`.
 
 ### [ ] E21-7 관측성 보강
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -492,12 +492,12 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: stale reservation이 일정 시간 후 반환된다.
 - 검증: `BudgetReservationServiceTest`, `BudgetReservationRecoveryJobTest`, `GatewayChatServiceUnitTest`.
 
-### [ ] E21-7 관측성 보강
+### [x] E21-7 관측성 보강
 
 - 목표: 운영자가 reservation 상태를 관측할 수 있게 한다.
 - 범위: metrics, log fields, fail reason 정리.
 - 완료 조건: reserve/settle/release/expire 이벤트가 메트릭으로 보인다.
-- 검증: actuator metrics 확인.
+- 검증: `BudgetReservationMetricsTest`, `BudgetReservationServiceTest`, `BudgetReservationRecoveryJobTest`, `GatewayChatServiceUnitTest`.
 
 ### [ ] E21-8 동시성 테스트 확대
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -499,19 +499,19 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: reserve/settle/release/expire 이벤트가 메트릭으로 보인다.
 - 검증: `BudgetReservationMetricsTest`, `BudgetReservationServiceTest`, `BudgetReservationRecoveryJobTest`, `GatewayChatServiceUnitTest`.
 
-### [ ] E21-8 동시성 테스트 확대
+### [x] E21-8 동시성 테스트 확대
 
 - 목표: hard-limit 일관성을 자동 테스트로 고정한다.
 - 범위: repository concurrency test, integration test, failover + reservation test.
 - 완료 조건: 같은 scope에서 허용 수만 통과하고 나머지는 차단된다.
-- 검증: targeted gradle tests.
+- 검증: `BudgetMonthlyUsageRepositoryTest`, `BudgetReservationServiceConcurrencyTest`, `BudgetReservationServiceTest`, `GatewayChatServiceUnitTest`.
 
-### [ ] E21-9 문서 동기화
+### [x] E21-9 문서 동기화
 
 - 목표: 구현 변경이 제품/DB/API 문서에 반영되게 한다.
 - 범위: `.ai/features.md`, `.ai/api-implemented.md`, `.ai/database.md`, `.ai/tasklist.md`.
 - 완료 조건: hard-limit 설명이 `사전 예약 + 사후 정산` 기준으로 정렬된다.
-- 검증: 문서 리뷰.
+- 검증: `docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md` 및 `.ai/*` 문서 리뷰.
 
 ## 16) 테스트 전략
 
@@ -547,7 +547,13 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 2. 결과: 정확히 1건만 reserve 성공
 3. 다른 1건은 budget blocked
 
-이 테스트가 이번 변경의 핵심 acceptance criteria다.
+고정된 회귀 테스트:
+
+1. `BudgetMonthlyUsageRepositoryTest`: 같은 scope에서 동시 reserve 2건 중 1건만 성공
+2. `BudgetReservationServiceConcurrencyTest`: service 계층에서 reservation row 1건만 생성되고 `reserved_cost_usd`가 정확히 유지되는지 검증
+3. `GatewayChatServiceUnitTest`: hard-limit 차단 시 provider call이 발생하지 않고, failover 재예약 경로가 release 이후 다시 수행되는지 검증
+
+이 테스트 묶음이 이번 변경의 핵심 acceptance criteria다.
 
 ## 17) 운영 메트릭 및 로그
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -478,12 +478,12 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: reserve amount가 provider/model별로 재현 가능하다.
 - 검증: `BudgetReservationEstimatorTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
-### [ ] E21-5 Gateway 흐름 통합
+### [x] E21-5 Gateway 흐름 통합
 
 - 목표: provider call 전에 reserve, 종료 후 settle/release가 되도록 바꾼다.
 - 범위: primary, failover, blocked, timeout, unexpected exception 경로.
 - 완료 조건: 예약 성공한 요청만 provider call을 수행한다.
-- 검증: `GatewayChatServiceUnitTest`.
+- 검증: `GatewayChatServiceUnitTest`, `BudgetReservationEstimatorTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
 ### [ ] E21-6 TTL 복구 작업 도입
 

--- a/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
+++ b/docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md
@@ -229,12 +229,20 @@
 
 ```sql
 INSERT INTO budget_monthly_usage (
-    scope_type, scope_id, year_month, cost_usd, total_tokens, request_count, reserved_cost_usd
-) VALUES (
-    :scopeType, :scopeId, :yearMonth, 0, 0, 0, 0
+    scope_type, scope_id, year_month, cost_usd, total_tokens, request_count, reserved_cost_usd, created_at, updated_at
 )
-ON CONFLICT (scope_type, scope_id, year_month) DO NOTHING;
+SELECT
+    :scopeType, :scopeId, :yearMonth, 0, 0, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM budget_monthly_usage
+    WHERE scope_type = :scopeType
+      AND scope_id = :scopeId
+      AND year_month = :yearMonth
+);
 ```
+
+현재 repository 구현은 H2 기반 테스트 환경까지 같이 통과시키기 위해 위와 같은 조건부 insert를 사용하고, 동시 생성 경합은 unique 제약과 `DataIntegrityViolationException` 흡수로 마무리합니다. 실제 hard-limit 승인/거절의 일관성은 아래 `reserve update`가 담당합니다.
 
 ### 9-2) 예약 승인
 
@@ -456,12 +464,12 @@ soft-limit는 hard-limit처럼 차단보다 `DEGRADE`가 목적입니다.
 - 완료 조건: migration이 로컬/테스트 DB에 정상 적용된다.
 - 검증: Flyway migration 실행.
 
-### [ ] E21-3 Repository와 원자적 SQL 도입
+### [x] E21-3 Repository와 원자적 SQL 도입
 
 - 목표: reserve/settle/release를 native query로 구현한다.
 - 범위: usage upsert, reserve update, settle update, release update, stale reservation 조회.
 - 완료 조건: lost update 없이 row count 기반 예약 결과를 얻는다.
-- 검증: repository 단위 테스트.
+- 검증: `BudgetMonthlyUsageRepositoryTest`, `BudgetReservationRepositoryTest`, `BudgetReservationServiceTest`, `BudgetGuardrailServiceTest`.
 
 ### [ ] E21-4 최대 비용 상한 계산기 도입
 

--- a/src/main/java/com/llm_ops/demo/budget/config/BudgetReservationEstimationProperties.java
+++ b/src/main/java/com/llm_ops/demo/budget/config/BudgetReservationEstimationProperties.java
@@ -1,0 +1,31 @@
+package com.llm_ops.demo.budget.config;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "budget.reservation")
+@Getter
+@Setter
+public class BudgetReservationEstimationProperties {
+
+    private static final int DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+    private static final BigDecimal DEFAULT_INPUT_TOKEN_SAFETY_MULTIPLIER = new BigDecimal("1.10");
+
+    private int defaultMaxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS;
+    private BigDecimal inputTokenSafetyMultiplier = DEFAULT_INPUT_TOKEN_SAFETY_MULTIPLIER;
+
+    public int resolvedDefaultMaxOutputTokens() {
+        return defaultMaxOutputTokens > 0 ? defaultMaxOutputTokens : DEFAULT_MAX_OUTPUT_TOKENS;
+    }
+
+    public BigDecimal resolvedInputTokenSafetyMultiplier() {
+        if (inputTokenSafetyMultiplier == null || inputTokenSafetyMultiplier.compareTo(BigDecimal.ONE) < 0) {
+            return DEFAULT_INPUT_TOKEN_SAFETY_MULTIPLIER;
+        }
+        return inputTokenSafetyMultiplier;
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/domain/BudgetMonthlyUsage.java
+++ b/src/main/java/com/llm_ops/demo/budget/domain/BudgetMonthlyUsage.java
@@ -49,6 +49,9 @@ public class BudgetMonthlyUsage {
     @Column(name = "request_count", nullable = false)
     private Long requestCount;
 
+    @Column(name = "reserved_cost_usd", nullable = false, precision = 18, scale = 8)
+    private BigDecimal reservedCostUsd;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -65,6 +68,7 @@ public class BudgetMonthlyUsage {
         usage.costUsd = BigDecimal.ZERO;
         usage.totalTokens = 0L;
         usage.requestCount = 0L;
+        usage.reservedCostUsd = BigDecimal.ZERO;
         return usage;
     }
 
@@ -75,5 +79,16 @@ public class BudgetMonthlyUsage {
         this.totalTokens = (this.totalTokens != null ? this.totalTokens : 0L) + normalizedTokens;
         this.requestCount = (this.requestCount != null ? this.requestCount : 0L) + requestDelta;
     }
-}
 
+    public void reserveCost(BigDecimal amount) {
+        BigDecimal normalized = amount != null ? amount : BigDecimal.ZERO;
+        this.reservedCostUsd = (this.reservedCostUsd != null ? this.reservedCostUsd : BigDecimal.ZERO).add(normalized);
+    }
+
+    public void releaseReservedCost(BigDecimal amount) {
+        BigDecimal normalized = amount != null ? amount : BigDecimal.ZERO;
+        BigDecimal currentReserved = this.reservedCostUsd != null ? this.reservedCostUsd : BigDecimal.ZERO;
+        BigDecimal nextReserved = currentReserved.subtract(normalized);
+        this.reservedCostUsd = nextReserved.signum() >= 0 ? nextReserved : BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/domain/BudgetReservation.java
+++ b/src/main/java/com/llm_ops/demo/budget/domain/BudgetReservation.java
@@ -1,0 +1,145 @@
+package com.llm_ops.demo.budget.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@Table(
+    name = "budget_reservations",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"trace_id", "scope_type", "scope_id"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BudgetReservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "request_log_id")
+    private UUID requestLogId;
+
+    @Column(name = "trace_id", nullable = false, length = 64)
+    private String traceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "scope_type", nullable = false, length = 32)
+    private BudgetScopeType scopeType;
+
+    @Column(name = "scope_id", nullable = false)
+    private Long scopeId;
+
+    @Column(name = "year_month", nullable = false)
+    private Integer yearMonth;
+
+    @Column(name = "provider", length = 32)
+    private String provider;
+
+    @Column(name = "model", length = 128)
+    private String model;
+
+    @Column(name = "reserved_cost_usd", nullable = false, precision = 18, scale = 8)
+    private BigDecimal reservedCostUsd;
+
+    @Column(name = "settled_cost_usd", precision = 18, scale = 8)
+    private BigDecimal settledCostUsd;
+
+    @Column(name = "reserved_input_tokens")
+    private Integer reservedInputTokens;
+
+    @Column(name = "reserved_output_tokens")
+    private Integer reservedOutputTokens;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private BudgetReservationStatus status;
+
+    @Column(name = "release_reason", length = 64)
+    private String releaseReason;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static BudgetReservation reserve(
+        UUID requestLogId,
+        String traceId,
+        BudgetScopeType scopeType,
+        Long scopeId,
+        Integer yearMonth,
+        String provider,
+        String model,
+        BigDecimal reservedCostUsd,
+        Integer reservedInputTokens,
+        Integer reservedOutputTokens,
+        LocalDateTime expiresAt
+    ) {
+        BudgetReservation reservation = new BudgetReservation();
+        reservation.requestLogId = requestLogId;
+        reservation.traceId = traceId;
+        reservation.scopeType = scopeType;
+        reservation.scopeId = scopeId;
+        reservation.yearMonth = yearMonth;
+        reservation.provider = provider;
+        reservation.model = model;
+        reservation.reservedCostUsd = reservedCostUsd != null ? reservedCostUsd : BigDecimal.ZERO;
+        reservation.settledCostUsd = null;
+        reservation.reservedInputTokens = reservedInputTokens;
+        reservation.reservedOutputTokens = reservedOutputTokens;
+        reservation.status = BudgetReservationStatus.RESERVED;
+        reservation.releaseReason = null;
+        reservation.expiresAt = expiresAt;
+        return reservation;
+    }
+
+    public boolean isReserved() {
+        return status == BudgetReservationStatus.RESERVED;
+    }
+
+    public void markSettled(BigDecimal settledCostUsd) {
+        if (!isReserved()) {
+            return;
+        }
+        this.status = BudgetReservationStatus.SETTLED;
+        this.settledCostUsd = settledCostUsd != null ? settledCostUsd : BigDecimal.ZERO;
+        this.releaseReason = null;
+    }
+
+    public void markReleased(String releaseReason) {
+        if (!isReserved()) {
+            return;
+        }
+        this.status = BudgetReservationStatus.RELEASED;
+        this.releaseReason = releaseReason;
+    }
+
+    public void markExpired() {
+        if (!isReserved()) {
+            return;
+        }
+        this.status = BudgetReservationStatus.EXPIRED;
+        this.releaseReason = "RESERVATION_EXPIRED";
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/domain/BudgetReservationStatus.java
+++ b/src/main/java/com/llm_ops/demo/budget/domain/BudgetReservationStatus.java
@@ -1,0 +1,8 @@
+package com.llm_ops.demo.budget.domain;
+
+public enum BudgetReservationStatus {
+    RESERVED,
+    SETTLED,
+    RELEASED,
+    EXPIRED
+}

--- a/src/main/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepository.java
+++ b/src/main/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepository.java
@@ -2,8 +2,12 @@ package com.llm_ops.demo.budget.repository;
 
 import com.llm_ops.demo.budget.domain.BudgetMonthlyUsage;
 import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import java.math.BigDecimal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BudgetMonthlyUsageRepository extends JpaRepository<BudgetMonthlyUsage, Long> {
     Optional<BudgetMonthlyUsage> findByScopeTypeAndScopeIdAndYearMonth(
@@ -11,5 +15,98 @@ public interface BudgetMonthlyUsageRepository extends JpaRepository<BudgetMonthl
         Long scopeId,
         Integer yearMonth
     );
-}
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = """
+            INSERT INTO budget_monthly_usage (
+                scope_type,
+                scope_id,
+                year_month,
+                cost_usd,
+                total_tokens,
+                request_count,
+                reserved_cost_usd
+            ) VALUES (
+                :scopeType,
+                :scopeId,
+                :yearMonth,
+                0,
+                0,
+                0,
+                0
+            )
+            ON CONFLICT (scope_type, scope_id, year_month) DO NOTHING
+            """,
+        nativeQuery = true
+    )
+    int ensureUsageRow(
+        @Param("scopeType") String scopeType,
+        @Param("scopeId") Long scopeId,
+        @Param("yearMonth") Integer yearMonth
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = """
+            UPDATE budget_monthly_usage
+            SET reserved_cost_usd = reserved_cost_usd + :reserveAmount
+            WHERE scope_type = :scopeType
+              AND scope_id = :scopeId
+              AND year_month = :yearMonth
+              AND cost_usd + reserved_cost_usd + :reserveAmount <= :monthLimitUsd
+            """,
+        nativeQuery = true
+    )
+    int reserveCostIfWithinLimit(
+        @Param("scopeType") String scopeType,
+        @Param("scopeId") Long scopeId,
+        @Param("yearMonth") Integer yearMonth,
+        @Param("reserveAmount") BigDecimal reserveAmount,
+        @Param("monthLimitUsd") BigDecimal monthLimitUsd
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = """
+            UPDATE budget_monthly_usage
+            SET reserved_cost_usd = reserved_cost_usd - :reservedAmount,
+                cost_usd = cost_usd + :actualCostUsd,
+                total_tokens = total_tokens + :totalTokensDelta,
+                request_count = request_count + :requestCountDelta
+            WHERE scope_type = :scopeType
+              AND scope_id = :scopeId
+              AND year_month = :yearMonth
+              AND reserved_cost_usd >= :reservedAmount
+            """,
+        nativeQuery = true
+    )
+    int settleReservation(
+        @Param("scopeType") String scopeType,
+        @Param("scopeId") Long scopeId,
+        @Param("yearMonth") Integer yearMonth,
+        @Param("reservedAmount") BigDecimal reservedAmount,
+        @Param("actualCostUsd") BigDecimal actualCostUsd,
+        @Param("totalTokensDelta") Long totalTokensDelta,
+        @Param("requestCountDelta") Long requestCountDelta
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = """
+            UPDATE budget_monthly_usage
+            SET reserved_cost_usd = reserved_cost_usd - :reservedAmount
+            WHERE scope_type = :scopeType
+              AND scope_id = :scopeId
+              AND year_month = :yearMonth
+              AND reserved_cost_usd >= :reservedAmount
+            """,
+        nativeQuery = true
+    )
+    int releaseReservedCost(
+        @Param("scopeType") String scopeType,
+        @Param("scopeId") Long scopeId,
+        @Param("yearMonth") Integer yearMonth,
+        @Param("reservedAmount") BigDecimal reservedAmount
+    );
+}

--- a/src/main/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepository.java
+++ b/src/main/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepository.java
@@ -26,17 +26,27 @@ public interface BudgetMonthlyUsageRepository extends JpaRepository<BudgetMonthl
                 cost_usd,
                 total_tokens,
                 request_count,
-                reserved_cost_usd
-            ) VALUES (
+                reserved_cost_usd,
+                created_at,
+                updated_at
+            )
+            SELECT
                 :scopeType,
                 :scopeId,
                 :yearMonth,
                 0,
                 0,
                 0,
-                0
+                0,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM budget_monthly_usage
+                WHERE scope_type = :scopeType
+                  AND scope_id = :scopeId
+                  AND year_month = :yearMonth
             )
-            ON CONFLICT (scope_type, scope_id, year_month) DO NOTHING
             """,
         nativeQuery = true
     )

--- a/src/main/java/com/llm_ops/demo/budget/repository/BudgetReservationRepository.java
+++ b/src/main/java/com/llm_ops/demo/budget/repository/BudgetReservationRepository.java
@@ -1,0 +1,22 @@
+package com.llm_ops.demo.budget.repository;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetReservationRepository extends JpaRepository<BudgetReservation, Long> {
+    Optional<BudgetReservation> findByTraceIdAndScopeTypeAndScopeId(
+        String traceId,
+        BudgetScopeType scopeType,
+        Long scopeId
+    );
+
+    List<BudgetReservation> findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
+        BudgetReservationStatus status,
+        LocalDateTime expiresAt
+    );
+}

--- a/src/main/java/com/llm_ops/demo/budget/repository/BudgetReservationRepository.java
+++ b/src/main/java/com/llm_ops/demo/budget/repository/BudgetReservationRepository.java
@@ -7,6 +7,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BudgetReservationRepository extends JpaRepository<BudgetReservation, Long> {
     Optional<BudgetReservation> findByTraceIdAndScopeTypeAndScopeId(
@@ -18,5 +21,48 @@ public interface BudgetReservationRepository extends JpaRepository<BudgetReserva
     List<BudgetReservation> findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
         BudgetReservationStatus status,
         LocalDateTime expiresAt
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update BudgetReservation r
+        set r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.SETTLED,
+            r.settledCostUsd = :settledCostUsd,
+            r.releaseReason = null,
+            r.updatedAt = CURRENT_TIMESTAMP
+        where r.id = :reservationId
+          and r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.RESERVED
+        """)
+    int markSettledIfReserved(
+        @Param("reservationId") Long reservationId,
+        @Param("settledCostUsd") java.math.BigDecimal settledCostUsd
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update BudgetReservation r
+        set r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.RELEASED,
+            r.releaseReason = :releaseReason,
+            r.updatedAt = CURRENT_TIMESTAMP
+        where r.id = :reservationId
+          and r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.RESERVED
+        """)
+    int markReleasedIfReserved(
+        @Param("reservationId") Long reservationId,
+        @Param("releaseReason") String releaseReason
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update BudgetReservation r
+        set r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.EXPIRED,
+            r.releaseReason = :releaseReason,
+            r.updatedAt = CURRENT_TIMESTAMP
+        where r.id = :reservationId
+          and r.status = com.llm_ops.demo.budget.domain.BudgetReservationStatus.RESERVED
+        """)
+    int markExpiredIfReserved(
+        @Param("reservationId") Long reservationId,
+        @Param("releaseReason") String releaseReason
     );
 }

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetGuardrailService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetGuardrailService.java
@@ -33,12 +33,16 @@ public class BudgetGuardrailService {
         }
 
         YearMonth ym = budgetUsageService.currentUtcYearMonth();
-        BigDecimal used = budgetUsageService
+        BigDecimal projectedSpend = budgetUsageService
             .findUsage(BudgetScopeType.PROVIDER_CREDENTIAL, providerCredentialId, ym)
-            .map(u -> u.getCostUsd())
+            .map(u -> {
+                BigDecimal spent = u.getCostUsd() != null ? u.getCostUsd() : BigDecimal.ZERO;
+                BigDecimal reserved = u.getReservedCostUsd() != null ? u.getReservedCostUsd() : BigDecimal.ZERO;
+                return spent.add(reserved);
+            })
             .orElse(BigDecimal.ZERO);
 
-        if (used.compareTo(policy.getMonthLimitUsd()) >= 0) {
+        if (projectedSpend.compareTo(policy.getMonthLimitUsd()) >= 0) {
             return new BudgetDecision(
                 BudgetDecisionAction.BLOCK,
                 BudgetScopeType.PROVIDER_CREDENTIAL,
@@ -65,12 +69,16 @@ public class BudgetGuardrailService {
         }
 
         YearMonth ym = budgetUsageService.currentUtcYearMonth();
-        BigDecimal used = budgetUsageService
+        BigDecimal projectedSpend = budgetUsageService
             .findUsage(BudgetScopeType.WORKSPACE, workspaceId, ym)
-            .map(u -> u.getCostUsd())
+            .map(u -> {
+                BigDecimal spent = u.getCostUsd() != null ? u.getCostUsd() : BigDecimal.ZERO;
+                BigDecimal reserved = u.getReservedCostUsd() != null ? u.getReservedCostUsd() : BigDecimal.ZERO;
+                return spent.add(reserved);
+            })
             .orElse(BigDecimal.ZERO);
 
-        if (used.compareTo(policy.getSoftLimitUsd()) < 0) {
+        if (projectedSpend.compareTo(policy.getSoftLimitUsd()) < 0) {
             return BudgetDecision.allow();
         }
 

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationCommandService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationCommandService.java
@@ -1,0 +1,75 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetReservationCommandService {
+
+    private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+    private final BudgetReservationRepository budgetReservationRepository;
+    private final BudgetUsageRowInitializer budgetUsageRowInitializer;
+    private final BudgetReservationMetrics budgetReservationMetrics;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Optional<BudgetReservation> reserve(
+        UUID requestLogId,
+        String traceId,
+        BudgetScopeType scopeType,
+        Long scopeId,
+        Integer yearMonth,
+        BigDecimal monthLimitUsd,
+        BigDecimal reserveAmount,
+        String provider,
+        String model,
+        Integer reservedInputTokens,
+        Integer reservedOutputTokens,
+        LocalDateTime expiresAt
+    ) {
+        try {
+            budgetUsageRowInitializer.ensureUsageRow(scopeType.name(), scopeId, yearMonth);
+        } catch (DataIntegrityViolationException ignored) {
+            // 동시 생성 경쟁으로 unique 충돌이 나도 다음 reserve 단계에서 동일 row를 사용하면 된다.
+        }
+
+        int reserved = budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            scopeType.name(),
+            scopeId,
+            yearMonth,
+            reserveAmount,
+            monthLimitUsd
+        );
+        if (reserved <= 0) {
+            budgetReservationMetrics.incrementReserveFailed(scopeType, "LIMIT_EXCEEDED");
+            return Optional.empty();
+        }
+
+        BudgetReservation saved = budgetReservationRepository.save(BudgetReservation.reserve(
+            requestLogId,
+            traceId,
+            scopeType,
+            scopeId,
+            yearMonth,
+            provider,
+            model,
+            reserveAmount,
+            reservedInputTokens,
+            reservedOutputTokens,
+            expiresAt
+        ));
+        budgetReservationMetrics.incrementReserve(scopeType);
+        return Optional.of(saved);
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationEstimate.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationEstimate.java
@@ -1,0 +1,32 @@
+package com.llm_ops.demo.budget.service;
+
+import java.math.BigDecimal;
+
+public record BudgetReservationEstimate(
+    String pricingModel,
+    Integer reservedInputTokens,
+    Integer reservedOutputTokens,
+    BigDecimal reserveAmountUsd,
+    boolean reservable,
+    String rejectionReason
+) {
+    public static BudgetReservationEstimate reservable(
+        String pricingModel,
+        Integer reservedInputTokens,
+        Integer reservedOutputTokens,
+        BigDecimal reserveAmountUsd
+    ) {
+        return new BudgetReservationEstimate(
+            pricingModel,
+            reservedInputTokens,
+            reservedOutputTokens,
+            reserveAmountUsd,
+            true,
+            null
+        );
+    }
+
+    public static BudgetReservationEstimate unavailable(String pricingModel, String rejectionReason) {
+        return new BudgetReservationEstimate(pricingModel, null, null, null, false, rejectionReason);
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationEstimator.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationEstimator.java
@@ -1,0 +1,77 @@
+package com.llm_ops.demo.budget.service;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+import com.llm_ops.demo.budget.config.BudgetReservationEstimationProperties;
+import com.llm_ops.demo.gateway.pricing.ModelPricing;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BudgetReservationEstimator {
+
+    public static final String PRICING_UNAVAILABLE_REASON = "BUDGET_PRICING_UNAVAILABLE";
+
+    private final BudgetReservationEstimationProperties properties;
+    private final EncodingRegistry registry = Encodings.newLazyEncodingRegistry();
+    private final Encoding encoding = registry.getEncoding(EncodingType.CL100K_BASE);
+
+    public BudgetReservationEstimator(BudgetReservationEstimationProperties properties) {
+        this.properties = properties;
+    }
+
+    public BudgetReservationEstimate estimate(
+        String pricingModel,
+        String systemPrompt,
+        String userPrompt,
+        Integer effectiveMaxTokens
+    ) {
+        if (pricingModel == null || pricingModel.isBlank() || !ModelPricing.isKnownModel(pricingModel)) {
+            return BudgetReservationEstimate.unavailable(pricingModel, PRICING_UNAVAILABLE_REASON);
+        }
+
+        int reservedInputTokens = estimateInputTokenUpperBound(systemPrompt, userPrompt);
+        int reservedOutputTokens = resolveOutputTokenUpperBound(effectiveMaxTokens);
+        BigDecimal reserveAmountUsd = ModelPricing.calculateCost(pricingModel, reservedInputTokens, reservedOutputTokens);
+
+        return BudgetReservationEstimate.reservable(
+            pricingModel,
+            reservedInputTokens,
+            reservedOutputTokens,
+            reserveAmountUsd
+        );
+    }
+
+    int estimateInputTokenUpperBound(String systemPrompt, String userPrompt) {
+        long rawInputTokens = (long) countTokens(systemPrompt) + countTokens(userPrompt);
+        if (rawInputTokens <= 0L) {
+            return 0;
+        }
+
+        BigDecimal scaled = BigDecimal.valueOf(rawInputTokens)
+            .multiply(properties.resolvedInputTokenSafetyMultiplier())
+            .setScale(0, RoundingMode.CEILING);
+
+        if (scaled.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0) {
+            return Integer.MAX_VALUE;
+        }
+        return scaled.intValueExact();
+    }
+
+    int resolveOutputTokenUpperBound(Integer effectiveMaxTokens) {
+        if (effectiveMaxTokens != null && effectiveMaxTokens > 0) {
+            return effectiveMaxTokens;
+        }
+        return properties.resolvedDefaultMaxOutputTokens();
+    }
+
+    private int countTokens(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        return encoding.countTokens(text);
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationMetrics.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationMetrics.java
@@ -1,0 +1,49 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BudgetReservationMetrics {
+
+    private final MeterRegistry registry;
+
+    public BudgetReservationMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void incrementReserve(BudgetScopeType scopeType) {
+        counter("gateway_budget_reserve_total", scopeType, null).increment();
+    }
+
+    public void incrementReserveFailed(BudgetScopeType scopeType, String reason) {
+        counter("gateway_budget_reserve_failed_total", scopeType, reason).increment();
+    }
+
+    public void incrementSettle(BudgetScopeType scopeType) {
+        counter("gateway_budget_settle_total", scopeType, null).increment();
+    }
+
+    public void incrementRelease(BudgetScopeType scopeType, String reason) {
+        counter("gateway_budget_release_total", scopeType, reason).increment();
+    }
+
+    public void incrementExpired(BudgetScopeType scopeType) {
+        counter("gateway_budget_reservation_expired_total", scopeType, null).increment();
+    }
+
+    private Counter counter(String name, BudgetScopeType scopeType, String reason) {
+        Counter.Builder builder = Counter.builder(name)
+            .tag("scope_type", safeScope(scopeType));
+        if (reason != null && !reason.isBlank()) {
+            builder.tag("reason", reason);
+        }
+        return builder.register(registry);
+    }
+
+    private String safeScope(BudgetScopeType scopeType) {
+        return scopeType != null ? scopeType.name().toLowerCase() : "unknown";
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationRecoveryJob.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationRecoveryJob.java
@@ -1,0 +1,19 @@
+package com.llm_ops.demo.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class BudgetReservationRecoveryJob {
+
+    private final BudgetReservationService budgetReservationService;
+
+    @Scheduled(fixedDelayString = "${budget.reservation.expire-sweep-fixed-delay-ms:30000}")
+    public void expireStaleReservations() {
+        budgetReservationService.expireStaleReservations();
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -1,0 +1,208 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
+import com.llm_ops.demo.global.error.BusinessException;
+import com.llm_ops.demo.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetReservationService {
+
+    private static final Duration DEFAULT_RESERVATION_TTL = Duration.ofSeconds(70);
+    private static final String EXPIRED_REASON = "RESERVATION_EXPIRED";
+
+    private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+    private final BudgetReservationRepository budgetReservationRepository;
+    private final Clock clock = Clock.systemUTC();
+
+    @Transactional
+    public Optional<BudgetReservation> reserve(
+        UUID requestLogId,
+        String traceId,
+        BudgetScopeType scopeType,
+        Long scopeId,
+        YearMonth yearMonth,
+        BigDecimal monthLimitUsd,
+        BigDecimal reserveAmount,
+        String provider,
+        String model,
+        Integer reservedInputTokens,
+        Integer reservedOutputTokens,
+        Duration ttl
+    ) {
+        if (traceId == null || traceId.isBlank() || scopeType == null || scopeId == null || scopeId <= 0 || yearMonth == null) {
+            return Optional.empty();
+        }
+        if (monthLimitUsd == null || monthLimitUsd.signum() <= 0) {
+            return Optional.empty();
+        }
+
+        BigDecimal normalizedReserveAmount = normalizeUsd(reserveAmount);
+        if (normalizedReserveAmount.signum() <= 0) {
+            return Optional.empty();
+        }
+
+        int yearMonthInt = BudgetUsageService.toYearMonthInt(yearMonth);
+        budgetMonthlyUsageRepository.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
+
+        int reserved = budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            scopeType.name(),
+            scopeId,
+            yearMonthInt,
+            normalizedReserveAmount,
+            monthLimitUsd
+        );
+        if (reserved <= 0) {
+            return Optional.empty();
+        }
+
+        BudgetReservation reservation = BudgetReservation.reserve(
+            requestLogId,
+            traceId,
+            scopeType,
+            scopeId,
+            yearMonthInt,
+            provider,
+            model,
+            normalizedReserveAmount,
+            reservedInputTokens,
+            reservedOutputTokens,
+            now().plus(resolveTtl(ttl))
+        );
+
+        try {
+            return Optional.of(budgetReservationRepository.save(reservation));
+        } catch (DataIntegrityViolationException exception) {
+            budgetMonthlyUsageRepository.releaseReservedCost(scopeType.name(), scopeId, yearMonthInt, normalizedReserveAmount);
+            return budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(traceId, scopeType, scopeId);
+        }
+    }
+
+    @Transactional
+    public void settle(Long reservationId, BigDecimal actualCostUsd, Long totalTokensDelta) {
+        BudgetReservation reservation = getReservationOrThrow(reservationId);
+        if (!reservation.isReserved()) {
+            return;
+        }
+
+        BigDecimal normalizedActualCost = normalizeUsd(actualCostUsd);
+        long normalizedTokens = totalTokensDelta != null ? Math.max(0L, totalTokensDelta) : 0L;
+        int updated = budgetMonthlyUsageRepository.settleReservation(
+            reservation.getScopeType().name(),
+            reservation.getScopeId(),
+            reservation.getYearMonth(),
+            reservation.getReservedCostUsd(),
+            normalizedActualCost,
+            normalizedTokens,
+            1L
+        );
+        if (updated <= 0) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 정산에 실패했습니다.");
+        }
+        reservation.markSettled(normalizedActualCost);
+    }
+
+    @Transactional
+    public void release(Long reservationId, String releaseReason) {
+        BudgetReservation reservation = getReservationOrThrow(reservationId);
+        releaseReservation(reservation, releaseReason);
+    }
+
+    @Transactional
+    public int expireStaleReservations() {
+        List<BudgetReservation> staleReservations = budgetReservationRepository
+            .findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(BudgetReservationStatus.RESERVED, now());
+        if (staleReservations.isEmpty()) {
+            return 0;
+        }
+
+        int expiredCount = 0;
+        for (BudgetReservation reservation : staleReservations) {
+            if (!reservation.isReserved()) {
+                continue;
+            }
+            int updated = budgetMonthlyUsageRepository.releaseReservedCost(
+                reservation.getScopeType().name(),
+                reservation.getScopeId(),
+                reservation.getYearMonth(),
+                reservation.getReservedCostUsd()
+            );
+            if (updated <= 0) {
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "만료된 예산 예약 복구에 실패했습니다.");
+            }
+            reservation.markExpired();
+            expiredCount++;
+        }
+        return expiredCount;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<BudgetReservation> findByTraceIdAndScopeTypeAndScopeId(
+        String traceId,
+        BudgetScopeType scopeType,
+        Long scopeId
+    ) {
+        if (traceId == null || traceId.isBlank() || scopeType == null || scopeId == null || scopeId <= 0) {
+            return Optional.empty();
+        }
+        return budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(traceId, scopeType, scopeId);
+    }
+
+    private void releaseReservation(BudgetReservation reservation, String releaseReason) {
+        if (reservation == null || !reservation.isReserved()) {
+            return;
+        }
+
+        int updated = budgetMonthlyUsageRepository.releaseReservedCost(
+            reservation.getScopeType().name(),
+            reservation.getScopeId(),
+            reservation.getYearMonth(),
+            reservation.getReservedCostUsd()
+        );
+        if (updated <= 0) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 반환에 실패했습니다.");
+        }
+        reservation.markReleased(releaseReason);
+    }
+
+    private BudgetReservation getReservationOrThrow(Long reservationId) {
+        if (reservationId == null || reservationId <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "reservationId가 올바르지 않습니다.");
+        }
+        return budgetReservationRepository.findById(reservationId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "예산 예약을 찾을 수 없습니다."));
+    }
+
+    private Duration resolveTtl(Duration ttl) {
+        if (ttl == null || ttl.isNegative() || ttl.isZero()) {
+            return DEFAULT_RESERVATION_TTL;
+        }
+        return ttl;
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.ofInstant(Instant.now(clock), ZoneOffset.UTC);
+    }
+
+    private BigDecimal normalizeUsd(BigDecimal amount) {
+        return amount != null ? amount.max(BigDecimal.ZERO) : BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -31,6 +31,7 @@ public class BudgetReservationService {
 
     private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
     private final BudgetReservationRepository budgetReservationRepository;
+    private final BudgetUsageRowInitializer budgetUsageRowInitializer;
     private final BudgetReservationMetrics budgetReservationMetrics;
     private final Clock clock = Clock.systemUTC();
 
@@ -63,7 +64,7 @@ public class BudgetReservationService {
 
         int yearMonthInt = BudgetUsageService.toYearMonthInt(yearMonth);
         try {
-            budgetMonthlyUsageRepository.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
+            budgetUsageRowInitializer.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
         } catch (DataIntegrityViolationException ignored) {
             // 동시 생성 경쟁으로 unique 충돌이 나도 다음 reserve 단계에서 동일 row를 사용하면 된다.
         }

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -31,7 +31,7 @@ public class BudgetReservationService {
 
     private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
     private final BudgetReservationRepository budgetReservationRepository;
-    private final BudgetUsageRowInitializer budgetUsageRowInitializer;
+    private final BudgetReservationCommandService budgetReservationCommandService;
     private final BudgetReservationMetrics budgetReservationMetrics;
     private final Clock clock = Clock.systemUTC();
 
@@ -62,46 +62,31 @@ public class BudgetReservationService {
             return Optional.empty();
         }
 
-        int yearMonthInt = BudgetUsageService.toYearMonthInt(yearMonth);
         try {
-            budgetUsageRowInitializer.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
-        } catch (DataIntegrityViolationException ignored) {
-            // 동시 생성 경쟁으로 unique 충돌이 나도 다음 reserve 단계에서 동일 row를 사용하면 된다.
-        }
-
-        int reserved = budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
-            scopeType.name(),
-            scopeId,
-            yearMonthInt,
-            normalizedReserveAmount,
-            monthLimitUsd
-        );
-        if (reserved <= 0) {
-            budgetReservationMetrics.incrementReserveFailed(scopeType, "LIMIT_EXCEEDED");
-            return Optional.empty();
-        }
-
-        BudgetReservation reservation = BudgetReservation.reserve(
-            requestLogId,
-            traceId,
-            scopeType,
-            scopeId,
-            yearMonthInt,
-            provider,
-            model,
-            normalizedReserveAmount,
-            reservedInputTokens,
-            reservedOutputTokens,
-            now().plus(resolveTtl(ttl))
-        );
-
-        try {
-            BudgetReservation saved = budgetReservationRepository.save(reservation);
-            budgetReservationMetrics.incrementReserve(scopeType);
-            return Optional.of(saved);
+            return budgetReservationCommandService.reserve(
+                requestLogId,
+                traceId,
+                scopeType,
+                scopeId,
+                BudgetUsageService.toYearMonthInt(yearMonth),
+                monthLimitUsd,
+                normalizedReserveAmount,
+                provider,
+                model,
+                reservedInputTokens,
+                reservedOutputTokens,
+                now().plus(resolveTtl(ttl))
+            );
         } catch (DataIntegrityViolationException exception) {
-            budgetMonthlyUsageRepository.releaseReservedCost(scopeType.name(), scopeId, yearMonthInt, normalizedReserveAmount);
-            return budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(traceId, scopeType, scopeId);
+            Optional<BudgetReservation> existingReservation = budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(
+                traceId,
+                scopeType,
+                scopeId
+            );
+            if (existingReservation.isPresent()) {
+                return existingReservation;
+            }
+            throw exception;
         }
     }
 

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -114,6 +114,14 @@ public class BudgetReservationService {
 
         BigDecimal normalizedActualCost = normalizeUsd(actualCostUsd);
         long normalizedTokens = totalTokensDelta != null ? Math.max(0L, totalTokensDelta) : 0L;
+        int transitioned = budgetReservationRepository.markSettledIfReserved(reservationId, normalizedActualCost);
+        if (transitioned <= 0) {
+            if (isAlreadyFinalized(reservationId)) {
+                return;
+            }
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 정산 상태 전이에 실패했습니다.");
+        }
+
         int updated = budgetMonthlyUsageRepository.settleReservation(
             reservation.getScopeType().name(),
             reservation.getScopeId(),
@@ -126,8 +134,6 @@ public class BudgetReservationService {
         if (updated <= 0) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 정산에 실패했습니다.");
         }
-        reservation.markSettled(normalizedActualCost);
-        budgetReservationRepository.save(reservation);
         budgetReservationMetrics.incrementSettle(reservation.getScopeType());
     }
 
@@ -150,6 +156,13 @@ public class BudgetReservationService {
             if (!reservation.isReserved()) {
                 continue;
             }
+            int transitioned = budgetReservationRepository.markExpiredIfReserved(reservation.getId(), EXPIRED_REASON);
+            if (transitioned <= 0) {
+                if (isAlreadyFinalized(reservation.getId())) {
+                    continue;
+                }
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "만료된 예산 예약 상태 전이에 실패했습니다.");
+            }
             int updated = budgetMonthlyUsageRepository.releaseReservedCost(
                 reservation.getScopeType().name(),
                 reservation.getScopeId(),
@@ -159,8 +172,6 @@ public class BudgetReservationService {
             if (updated <= 0) {
                 throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "만료된 예산 예약 복구에 실패했습니다.");
             }
-            reservation.markExpired();
-            budgetReservationRepository.save(reservation);
             budgetReservationMetrics.incrementExpired(reservation.getScopeType());
             expiredCount++;
         }
@@ -184,6 +195,14 @@ public class BudgetReservationService {
             return;
         }
 
+        int transitioned = budgetReservationRepository.markReleasedIfReserved(reservation.getId(), releaseReason);
+        if (transitioned <= 0) {
+            if (isAlreadyFinalized(reservation.getId())) {
+                return;
+            }
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 반환 상태 전이에 실패했습니다.");
+        }
+
         int updated = budgetMonthlyUsageRepository.releaseReservedCost(
             reservation.getScopeType().name(),
             reservation.getScopeId(),
@@ -193,9 +212,16 @@ public class BudgetReservationService {
         if (updated <= 0) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 반환에 실패했습니다.");
         }
-        reservation.markReleased(releaseReason);
-        budgetReservationRepository.save(reservation);
         budgetReservationMetrics.incrementRelease(reservation.getScopeType(), releaseReason);
+    }
+
+    private boolean isAlreadyFinalized(Long reservationId) {
+        return budgetReservationRepository.findById(reservationId)
+            .map(BudgetReservation::getStatus)
+            .filter(status -> status == BudgetReservationStatus.SETTLED
+                || status == BudgetReservationStatus.RELEASED
+                || status == BudgetReservationStatus.EXPIRED)
+            .isPresent();
     }
 
     private BudgetReservation getReservationOrThrow(Long reservationId) {

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -31,6 +31,7 @@ public class BudgetReservationService {
 
     private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
     private final BudgetReservationRepository budgetReservationRepository;
+    private final BudgetReservationMetrics budgetReservationMetrics;
     private final Clock clock = Clock.systemUTC();
 
     @Transactional
@@ -75,6 +76,7 @@ public class BudgetReservationService {
             monthLimitUsd
         );
         if (reserved <= 0) {
+            budgetReservationMetrics.incrementReserveFailed(scopeType, "LIMIT_EXCEEDED");
             return Optional.empty();
         }
 
@@ -93,7 +95,9 @@ public class BudgetReservationService {
         );
 
         try {
-            return Optional.of(budgetReservationRepository.save(reservation));
+            BudgetReservation saved = budgetReservationRepository.save(reservation);
+            budgetReservationMetrics.incrementReserve(scopeType);
+            return Optional.of(saved);
         } catch (DataIntegrityViolationException exception) {
             budgetMonthlyUsageRepository.releaseReservedCost(scopeType.name(), scopeId, yearMonthInt, normalizedReserveAmount);
             return budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(traceId, scopeType, scopeId);
@@ -122,6 +126,7 @@ public class BudgetReservationService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 정산에 실패했습니다.");
         }
         reservation.markSettled(normalizedActualCost);
+        budgetReservationMetrics.incrementSettle(reservation.getScopeType());
     }
 
     @Transactional
@@ -153,6 +158,7 @@ public class BudgetReservationService {
                 throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "만료된 예산 예약 복구에 실패했습니다.");
             }
             reservation.markExpired();
+            budgetReservationMetrics.incrementExpired(reservation.getScopeType());
             expiredCount++;
         }
         return expiredCount;
@@ -185,6 +191,7 @@ public class BudgetReservationService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 반환에 실패했습니다.");
         }
         reservation.markReleased(releaseReason);
+        budgetReservationMetrics.incrementRelease(reservation.getScopeType(), releaseReason);
     }
 
     private BudgetReservation getReservationOrThrow(Long reservationId) {

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -61,7 +61,11 @@ public class BudgetReservationService {
         }
 
         int yearMonthInt = BudgetUsageService.toYearMonthInt(yearMonth);
-        budgetMonthlyUsageRepository.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
+        try {
+            budgetMonthlyUsageRepository.ensureUsageRow(scopeType.name(), scopeId, yearMonthInt);
+        } catch (DataIntegrityViolationException ignored) {
+            // 동시 생성 경쟁으로 unique 충돌이 나도 다음 reserve 단계에서 동일 row를 사용하면 된다.
+        }
 
         int reserved = budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
             scopeType.name(),

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetReservationService.java
@@ -127,6 +127,7 @@ public class BudgetReservationService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 정산에 실패했습니다.");
         }
         reservation.markSettled(normalizedActualCost);
+        budgetReservationRepository.save(reservation);
         budgetReservationMetrics.incrementSettle(reservation.getScopeType());
     }
 
@@ -159,6 +160,7 @@ public class BudgetReservationService {
                 throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "만료된 예산 예약 복구에 실패했습니다.");
             }
             reservation.markExpired();
+            budgetReservationRepository.save(reservation);
             budgetReservationMetrics.incrementExpired(reservation.getScopeType());
             expiredCount++;
         }
@@ -192,6 +194,7 @@ public class BudgetReservationService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "예산 예약 반환에 실패했습니다.");
         }
         reservation.markReleased(releaseReason);
+        budgetReservationRepository.save(reservation);
         budgetReservationMetrics.incrementRelease(reservation.getScopeType(), releaseReason);
     }
 

--- a/src/main/java/com/llm_ops/demo/budget/service/BudgetUsageRowInitializer.java
+++ b/src/main/java/com/llm_ops/demo/budget/service/BudgetUsageRowInitializer.java
@@ -1,0 +1,19 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetUsageRowInitializer {
+
+    private final BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void ensureUsageRow(String scopeType, Long scopeId, Integer yearMonth) {
+        budgetMonthlyUsageRepository.ensureUsageRow(scopeType, scopeId, yearMonth);
+    }
+}

--- a/src/main/java/com/llm_ops/demo/gateway/service/GatewayChatService.java
+++ b/src/main/java/com/llm_ops/demo/gateway/service/GatewayChatService.java
@@ -193,6 +193,7 @@ public class GatewayChatService {
         boolean failoverAttempted = false;
         Long usedProviderCredentialId = null;
         BudgetReservation activeReservation = null;
+        BudgetReservation settlementReservation = null;
         String budgetFailReason = null;
         GatewayFailureClassifier.GatewayFailure lastProviderFailure = null;
         Long promptId = null;
@@ -502,6 +503,9 @@ public class GatewayChatService {
                 }
             }
 
+            settlementReservation = activeReservation;
+            activeReservation = null;
+
             String answer = response.getResult().getOutput().getText();
             String usedModel = response.getMetadata() != null ? response.getMetadata().getModel() : null;
 
@@ -548,21 +552,13 @@ public class GatewayChatService {
                     totalTokens != null ? totalTokens.longValue() : null,
                     estimatedCost);
 
-            // 예산 집계는 로그 async에 의존하지 않고 요청 스레드에서 동기 기록합니다.
-            budgetUsageService.recordUsage(
-                    BudgetScopeType.WORKSPACE,
-                    request.workspaceId(),
-                    budgetMonth,
-                    estimatedCost,
-                    totalTokens != null ? totalTokens.longValue() : null
-            );
-            if (activeReservation != null) {
+            // provider accounting을 먼저 확정해 성공 응답이 후처리 catch에서 release되지 않게 합니다.
+            if (settlementReservation != null) {
                 budgetReservationService.settle(
-                    activeReservation.getId(),
+                    settlementReservation.getId(),
                     estimatedCost,
                     totalTokens != null ? totalTokens.longValue() : null
                 );
-                activeReservation = null;
             } else {
                 budgetUsageService.recordUsage(
                     BudgetScopeType.PROVIDER_CREDENTIAL,
@@ -572,6 +568,14 @@ public class GatewayChatService {
                     totalTokens != null ? totalTokens.longValue() : null
                 );
             }
+            // 예산 집계는 로그 async에 의존하지 않고 요청 스레드에서 동기 기록합니다.
+            budgetUsageService.recordUsage(
+                    BudgetScopeType.WORKSPACE,
+                    request.workspaceId(),
+                    budgetMonth,
+                    estimatedCost,
+                    totalTokens != null ? totalTokens.longValue() : null
+            );
 
             requestLogWriter.markSuccess(requestId, new RequestLogWriter.SuccessUpdate(
                     200,

--- a/src/main/java/com/llm_ops/demo/gateway/service/GatewayChatService.java
+++ b/src/main/java/com/llm_ops/demo/gateway/service/GatewayChatService.java
@@ -1,10 +1,16 @@
 package com.llm_ops.demo.gateway.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.llm_ops.demo.budget.domain.BudgetPolicy;
+import com.llm_ops.demo.budget.domain.BudgetReservation;
 import com.llm_ops.demo.budget.domain.BudgetScopeType;
 import com.llm_ops.demo.budget.service.BudgetDecision;
 import com.llm_ops.demo.budget.service.BudgetDecisionAction;
 import com.llm_ops.demo.budget.service.BudgetGuardrailService;
+import com.llm_ops.demo.budget.service.BudgetPolicyService;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimate;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimator;
+import com.llm_ops.demo.budget.service.BudgetReservationService;
 import com.llm_ops.demo.budget.service.BudgetUsageService;
 import com.llm_ops.demo.gateway.config.GatewayReliabilityProperties;
 import com.llm_ops.demo.gateway.dto.GatewayChatRequest;
@@ -47,6 +53,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -94,6 +101,9 @@ public class GatewayChatService {
     private final PromptRepository promptRepository;
     private final PromptReleaseRepository promptReleaseRepository;
     private final BudgetGuardrailService budgetGuardrailService;
+    private final BudgetPolicyService budgetPolicyService;
+    private final BudgetReservationEstimator budgetReservationEstimator;
+    private final BudgetReservationService budgetReservationService;
     private final BudgetUsageService budgetUsageService;
     private final ExecutorService providerCallExecutor;
     private final GatewayMetrics gatewayMetrics;
@@ -112,6 +122,9 @@ public class GatewayChatService {
             PromptRepository promptRepository,
             PromptReleaseRepository promptReleaseRepository,
             BudgetGuardrailService budgetGuardrailService,
+            BudgetPolicyService budgetPolicyService,
+            BudgetReservationEstimator budgetReservationEstimator,
+            BudgetReservationService budgetReservationService,
             BudgetUsageService budgetUsageService,
             @Qualifier("providerCallExecutor") ExecutorService providerCallExecutor,
             GatewayMetrics gatewayMetrics,
@@ -128,6 +141,9 @@ public class GatewayChatService {
         this.promptRepository = promptRepository;
         this.promptReleaseRepository = promptReleaseRepository;
         this.budgetGuardrailService = budgetGuardrailService;
+        this.budgetPolicyService = budgetPolicyService;
+        this.budgetReservationEstimator = budgetReservationEstimator;
+        this.budgetReservationService = budgetReservationService;
         this.budgetUsageService = budgetUsageService;
         this.providerCallExecutor = providerCallExecutor;
         this.gatewayMetrics = gatewayMetrics;
@@ -176,6 +192,7 @@ public class GatewayChatService {
         String failoverReason = null;
         boolean failoverAttempted = false;
         Long usedProviderCredentialId = null;
+        BudgetReservation activeReservation = null;
         String budgetFailReason = null;
         GatewayFailureClassifier.GatewayFailure lastProviderFailure = null;
         Long promptId = null;
@@ -278,16 +295,34 @@ public class GatewayChatService {
             }
 
             ChatResponse response;
+            ModelConfigOverride primaryConfig = buildEffectiveModelConfig(versionModelConfig, maxOutputTokensOverride);
             ResolvedProviderApiKey primaryKey = providerCredentialService.resolveApiKey(organizationId, providerType);
             usedProviderCredentialId = primaryKey.credentialId();
 
             long provBudgetStartNanos = System.nanoTime();
             BudgetDecision providerDecision = budgetGuardrailService.evaluateProviderCredential(primaryKey.credentialId());
             gatewayMetrics.recordBudgetEval("provider_credential", System.nanoTime() - provBudgetStartNanos);
-            if (providerDecision.action() == BudgetDecisionAction.BLOCK) {
+            ProviderBudgetReservationResult primaryReservation = ProviderBudgetReservationResult.notRequired();
+            if (providerDecision.action() != BudgetDecisionAction.BLOCK) {
+                primaryReservation = reserveProviderBudget(
+                    requestId,
+                    traceId,
+                    budgetMonth,
+                    primaryKey,
+                    requestedModelEffective,
+                    systemPrompt,
+                    userPrompt,
+                    primaryConfig
+                );
+            }
+
+            if (providerDecision.action() == BudgetDecisionAction.BLOCK || primaryReservation.blocked()) {
+                String primaryBudgetBlockReason = providerDecision.action() == BudgetDecisionAction.BLOCK
+                    ? "PROVIDER_BUDGET_EXCEEDED"
+                    : primaryReservation.blockReason();
                 if (!hasSecondaryModel(secondaryProvider, secondaryModel)) {
                     gatewayMetrics.incrementBudgetBlocked("PROVIDER_CREDENTIAL");
-                    budgetFailReason = "PROVIDER_BUDGET_EXCEEDED";
+                    budgetFailReason = primaryBudgetBlockReason;
                     throw new BusinessException(ErrorCode.BUDGET_EXCEEDED, "예산 한도 초과로 요청이 차단되었습니다.");
                 }
                 ResolvedProviderApiKey secondaryKey = providerCredentialService.resolveApiKey(organizationId, secondaryProvider);
@@ -306,14 +341,14 @@ public class GatewayChatService {
                 failoverReason = "PRIMARY_PROVIDER_BUDGET_BLOCKED";
                 failoverAttempted = true;
                 gatewayMetrics.incrementFailover(
-                        providerType != null ? providerType.name().toLowerCase() : "unknown",
-                        secondaryProvider != null ? secondaryProvider.name().toLowerCase() : "unknown");
+                    providerType != null ? providerType.name().toLowerCase() : "unknown",
+                    secondaryProvider != null ? secondaryProvider.name().toLowerCase() : "unknown");
                 usedProvider = secondaryProvider;
                 usedProviderCredentialId = secondaryKey.credentialId();
 
                 BudgetDecision wsDecisionSecondary = budgetGuardrailService.evaluateWorkspaceDegrade(
-                        workspace.getId(),
-                        secondaryProvider != null ? secondaryProvider.getValue() : null
+                    workspace.getId(),
+                    secondaryProvider != null ? secondaryProvider.getValue() : null
                 );
                 String secondaryOverride = null;
                 Integer secondaryMaxTokens = maxOutputTokensOverride;
@@ -326,20 +361,37 @@ public class GatewayChatService {
                         secondaryMaxTokens = o2.maxOutputTokens();
                     }
                 }
+                ModelConfigOverride secondaryConfig = buildEffectiveModelConfig(versionModelConfig, secondaryMaxTokens);
                 String secondaryModelEffective = secondaryOverride != null ? secondaryOverride : secondaryModel;
                 usedRequestedModel = secondaryModelEffective;
+                ProviderBudgetReservationResult secondaryReservation = reserveProviderBudget(
+                    requestId,
+                    traceId,
+                    budgetMonth,
+                    secondaryKey,
+                    secondaryModelEffective,
+                    systemPrompt,
+                    userPrompt,
+                    secondaryConfig
+                );
+                if (secondaryReservation.blocked()) {
+                    gatewayMetrics.incrementBudgetBlocked("PROVIDER_CREDENTIAL");
+                    budgetFailReason = secondaryReservation.blockReason();
+                    throw new BusinessException(ErrorCode.BUDGET_EXCEEDED, "예산 한도 초과로 요청이 차단되었습니다.");
+                }
+                activeReservation = secondaryReservation.reservation();
 
                 providerCallStartNanos = System.nanoTime();
                 ProviderCallOutcome secondaryOutcome = callProviderWithPolicy(
-                        secondaryKey,
-                        secondaryModelEffective,
-                        systemPrompt,
-                        userPrompt,
-                        buildEffectiveModelConfig(versionModelConfig, secondaryMaxTokens),
-                        deadlineNanos,
-                        false,
-                        RequestLogAttemptRoute.FAILOVER,
-                        attemptCollector
+                    secondaryKey,
+                    secondaryModelEffective,
+                    systemPrompt,
+                    userPrompt,
+                    secondaryConfig,
+                    deadlineNanos,
+                    false,
+                    RequestLogAttemptRoute.FAILOVER,
+                    attemptCollector
                 );
                 if (!secondaryOutcome.success()) {
                     lastProviderFailure = secondaryOutcome.failure();
@@ -348,17 +400,18 @@ public class GatewayChatService {
                 response = secondaryOutcome.response();
                 providerCallEndNanos = System.nanoTime();
             } else {
+                activeReservation = primaryReservation.reservation();
                 providerCallStartNanos = System.nanoTime();
                 ProviderCallOutcome primaryOutcome = callProviderWithPolicy(
-                        primaryKey,
-                        requestedModelEffective,
-                        systemPrompt,
-                        userPrompt,
-                        buildEffectiveModelConfig(versionModelConfig, maxOutputTokensOverride),
-                        deadlineNanos,
-                        hasSecondaryModel(secondaryProvider, secondaryModel),
-                        RequestLogAttemptRoute.PRIMARY,
-                        attemptCollector
+                    primaryKey,
+                    requestedModelEffective,
+                    systemPrompt,
+                    userPrompt,
+                    primaryConfig,
+                    deadlineNanos,
+                    hasSecondaryModel(secondaryProvider, secondaryModel),
+                    RequestLogAttemptRoute.PRIMARY,
+                    attemptCollector
                 );
                 if (primaryOutcome.success()) {
                     response = primaryOutcome.response();
@@ -382,20 +435,20 @@ public class GatewayChatService {
 
                     isFailover = true;
                     failoverReason = (lastProviderFailure != null
-                            && lastProviderFailure.failReason() != null
-                            && !lastProviderFailure.failReason().isBlank())
-                            ? lastProviderFailure.failReason()
-                            : "PRIMARY_ROUTE_FAILED";
+                        && lastProviderFailure.failReason() != null
+                        && !lastProviderFailure.failReason().isBlank())
+                        ? lastProviderFailure.failReason()
+                        : "PRIMARY_ROUTE_FAILED";
                     failoverAttempted = true;
                     gatewayMetrics.incrementFailover(
-                            providerType != null ? providerType.name().toLowerCase() : "unknown",
-                            secondaryProvider != null ? secondaryProvider.name().toLowerCase() : "unknown");
+                        providerType != null ? providerType.name().toLowerCase() : "unknown",
+                        secondaryProvider != null ? secondaryProvider.name().toLowerCase() : "unknown");
                     usedProvider = secondaryProvider;
                     usedProviderCredentialId = secondaryKey.credentialId();
 
                     BudgetDecision wsDecisionSecondary = budgetGuardrailService.evaluateWorkspaceDegrade(
-                            workspace.getId(),
-                            secondaryProvider != null ? secondaryProvider.getValue() : null
+                        workspace.getId(),
+                        secondaryProvider != null ? secondaryProvider.getValue() : null
                     );
                     String secondaryOverride = null;
                     Integer secondaryMaxTokens = maxOutputTokensOverride;
@@ -408,20 +461,37 @@ public class GatewayChatService {
                             secondaryMaxTokens = o2.maxOutputTokens();
                         }
                     }
+                    ModelConfigOverride secondaryConfig = buildEffectiveModelConfig(versionModelConfig, secondaryMaxTokens);
                     String secondaryModelEffective = secondaryOverride != null ? secondaryOverride : secondaryModel;
                     usedRequestedModel = secondaryModelEffective;
+                    releaseReservationQuietly(activeReservation, "PRIMARY_ROUTE_FAILED");
+                    activeReservation = null;
+                    ProviderBudgetReservationResult secondaryReservation = reserveProviderBudget(
+                        requestId,
+                        traceId,
+                        budgetMonth,
+                        secondaryKey,
+                        secondaryModelEffective,
+                        systemPrompt,
+                        userPrompt,
+                        secondaryConfig
+                    );
+                    if (secondaryReservation.blocked()) {
+                        throw primaryException;
+                    }
+                    activeReservation = secondaryReservation.reservation();
 
                     providerCallStartNanos = System.nanoTime();
                     ProviderCallOutcome secondaryOutcome = callProviderWithPolicy(
-                            secondaryKey,
-                            secondaryModelEffective,
-                            systemPrompt,
-                            userPrompt,
-                            buildEffectiveModelConfig(versionModelConfig, secondaryMaxTokens),
-                            deadlineNanos,
-                            false,
-                            RequestLogAttemptRoute.FAILOVER,
-                            attemptCollector
+                        secondaryKey,
+                        secondaryModelEffective,
+                        systemPrompt,
+                        userPrompt,
+                        secondaryConfig,
+                        deadlineNanos,
+                        false,
+                        RequestLogAttemptRoute.FAILOVER,
+                        attemptCollector
                     );
                     if (!secondaryOutcome.success()) {
                         lastProviderFailure = secondaryOutcome.failure();
@@ -486,13 +556,22 @@ public class GatewayChatService {
                     estimatedCost,
                     totalTokens != null ? totalTokens.longValue() : null
             );
-            budgetUsageService.recordUsage(
+            if (activeReservation != null) {
+                budgetReservationService.settle(
+                    activeReservation.getId(),
+                    estimatedCost,
+                    totalTokens != null ? totalTokens.longValue() : null
+                );
+                activeReservation = null;
+            } else {
+                budgetUsageService.recordUsage(
                     BudgetScopeType.PROVIDER_CREDENTIAL,
                     usedProviderCredentialId,
                     budgetMonth,
                     estimatedCost,
                     totalTokens != null ? totalTokens.longValue() : null
-            );
+                );
+            }
 
             requestLogWriter.markSuccess(requestId, new RequestLogWriter.SuccessUpdate(
                     200,
@@ -539,6 +618,7 @@ public class GatewayChatService {
                     usedModel,
                     usage);
         } catch (BusinessException e) {
+            releaseReservationQuietly(activeReservation, budgetFailReason != null ? budgetFailReason : e.getErrorCode().name());
             String providerTag = usedProvider != null ? usedProvider.name().toLowerCase() : "unknown";
             String failReason = budgetFailReason != null ? budgetFailReason : e.getErrorCode().name();
             gatewayMetrics.recordRequest(providerTag, usedRequestedModel, ragEnabledEffective, isFailover, "error", System.nanoTime() - startedAtNanos);
@@ -607,6 +687,7 @@ public class GatewayChatService {
             }
             throw toGatewayException(gatewayFailure, e);
         } catch (Exception e) {
+            releaseReservationQuietly(activeReservation, lastProviderFailure != null ? lastProviderFailure.failReason() : e.getClass().getSimpleName());
             String providerTag = usedProvider != null ? usedProvider.name().toLowerCase() : "unknown";
             String exFailReason = lastProviderFailure != null ? lastProviderFailure.failReason() : e.getClass().getSimpleName();
             gatewayMetrics.recordRequest(providerTag, usedRequestedModel, ragEnabledEffective, isFailover, "error", System.nanoTime() - startedAtNanos);
@@ -709,6 +790,67 @@ public class GatewayChatService {
         return infos;
     }
 
+    private ProviderBudgetReservationResult reserveProviderBudget(
+        UUID requestId,
+        String traceId,
+        YearMonth budgetMonth,
+        ResolvedProviderApiKey providerKey,
+        String requestedModel,
+        String systemPrompt,
+        String userPrompt,
+        ModelConfigOverride config
+    ) {
+        if (providerKey == null || providerKey.credentialId() == null || providerKey.credentialId() <= 0) {
+            return ProviderBudgetReservationResult.notRequired();
+        }
+
+        BudgetPolicy policy = budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, providerKey.credentialId())
+            .filter(p -> Boolean.TRUE.equals(p.getEnabled()))
+            .filter(p -> p.getMonthLimitUsd() != null)
+            .orElse(null);
+        if (policy == null) {
+            return ProviderBudgetReservationResult.notRequired();
+        }
+
+        BudgetReservationEstimate estimate = budgetReservationEstimator.estimate(
+            requestedModel,
+            systemPrompt,
+            userPrompt,
+            config != null ? config.maxTokens() : null
+        );
+        if (!estimate.reservable()) {
+            return ProviderBudgetReservationResult.blocked(estimate.rejectionReason());
+        }
+
+        return budgetReservationService.reserve(
+            requestId,
+            traceId,
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            providerKey.credentialId(),
+            budgetMonth,
+            policy.getMonthLimitUsd(),
+            estimate.reserveAmountUsd(),
+            providerKey.providerType() != null ? providerKey.providerType().getValue() : null,
+            requestedModel,
+            estimate.reservedInputTokens(),
+            estimate.reservedOutputTokens(),
+            Duration.ofMillis(gatewayReliabilityProperties.resolvedRequestTimeoutMs() + 1_000L)
+        )
+            .map(ProviderBudgetReservationResult::reserved)
+            .orElseGet(() -> ProviderBudgetReservationResult.blocked("PROVIDER_BUDGET_EXCEEDED"));
+    }
+
+    private void releaseReservationQuietly(BudgetReservation reservation, String releaseReason) {
+        if (reservation == null || reservation.getId() == null) {
+            return;
+        }
+        try {
+            budgetReservationService.release(reservation.getId(), releaseReason);
+        } catch (Exception ignored) {
+            // cleanup 실패는 원래 gateway 실패를 덮어쓰지 않도록 삼킨다.
+        }
+    }
+
 
     private static String sha256HexOrNull(String value) {
         if (value == null || value.isBlank()) {
@@ -756,6 +898,24 @@ public class GatewayChatService {
         return workspaceRepository
                 .findByIdAndOrganizationIdAndStatus(workspaceId, organizationId, WorkspaceStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN, "워크스페이스 접근 권한이 없습니다."));
+    }
+
+    private record ProviderBudgetReservationResult(BudgetReservation reservation, String blockReason) {
+        static ProviderBudgetReservationResult notRequired() {
+            return new ProviderBudgetReservationResult(null, null);
+        }
+
+        static ProviderBudgetReservationResult reserved(BudgetReservation reservation) {
+            return new ProviderBudgetReservationResult(reservation, null);
+        }
+
+        static ProviderBudgetReservationResult blocked(String blockReason) {
+            return new ProviderBudgetReservationResult(null, blockReason != null ? blockReason : "PROVIDER_BUDGET_EXCEEDED");
+        }
+
+        boolean blocked() {
+            return blockReason != null;
+        }
     }
 
     private record ActiveVersionResolution(Long promptId, Long promptVersionId, PromptVersion version) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -127,6 +127,11 @@ jwt:
   expiration-sec: ${JWT_EXPIRATION:900}
   refresh-expiration-sec: 1209600
 
+budget:
+  reservation:
+    default-max-output-tokens: 2048
+    input-token-safety-multiplier: 1.10
+
 gateway:
   reliability:
     request-timeout-ms: 60000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,6 +131,7 @@ budget:
   reservation:
     default-max-output-tokens: 2048
     input-token-safety-multiplier: 1.10
+    expire-sweep-fixed-delay-ms: 30000
 
 gateway:
   reliability:

--- a/src/main/resources/db/migration/V33__budget_reservations.sql
+++ b/src/main/resources/db/migration/V33__budget_reservations.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- V33: Budget reservation / settlement foundation
+-- 목적:
+--  - hard-limit 동시성 제어를 위한 reserved 비용 추적 컬럼 추가
+--  - 요청 단위 reservation 상태 추적 테이블 추가
+-- ============================================================
+
+ALTER TABLE budget_monthly_usage
+    ADD COLUMN IF NOT EXISTS reserved_cost_usd NUMERIC(18, 8) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS budget_reservations (
+    id BIGSERIAL PRIMARY KEY,
+    request_log_id UUID,
+    trace_id VARCHAR(64) NOT NULL,
+    scope_type VARCHAR(32) NOT NULL,
+    scope_id BIGINT NOT NULL,
+    year_month INTEGER NOT NULL,
+    provider VARCHAR(32),
+    model VARCHAR(128),
+    reserved_cost_usd NUMERIC(18, 8) NOT NULL,
+    settled_cost_usd NUMERIC(18, 8),
+    reserved_input_tokens INTEGER,
+    reserved_output_tokens INTEGER,
+    status VARCHAR(32) NOT NULL,
+    release_reason VARCHAR(64),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_budget_reservations_trace_scope UNIQUE (trace_id, scope_type, scope_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_reservations_scope_month_status
+    ON budget_reservations (scope_type, scope_id, year_month, status);
+
+CREATE INDEX IF NOT EXISTS idx_budget_reservations_status_expires
+    ON budget_reservations (status, expires_at);

--- a/src/test/java/com/llm_ops/demo/budget/BudgetReservationMigrationTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/BudgetReservationMigrationTest.java
@@ -1,0 +1,97 @@
+package com.llm_ops.demo.budget;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BudgetReservationMigrationTest {
+
+    @Test
+    @DisplayName("예산 reservation migration을 적용한다")
+    void 예산_reservation_migration을_적용한다() throws Exception {
+        // given
+        String url =
+            "jdbc:h2:mem:budgetreservationmigration;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"
+                + ";INIT=CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE";
+
+        try (Connection connection = DriverManager.getConnection(url, "sa", "")) {
+            ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource("db/migration/V19__budget_policies_and_usage.sql")));
+
+            // when
+            ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource("db/migration/V33__budget_reservations.sql")));
+
+            try (
+                PreparedStatement usageInsert = connection.prepareStatement(
+                    """
+                        INSERT INTO budget_monthly_usage (
+                            scope_type,
+                            scope_id,
+                            year_month,
+                            cost_usd,
+                            total_tokens,
+                            request_count,
+                            reserved_cost_usd
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """
+                );
+                PreparedStatement reservationInsert = connection.prepareStatement(
+                    """
+                        INSERT INTO budget_reservations (
+                            trace_id,
+                            scope_type,
+                            scope_id,
+                            year_month,
+                            provider,
+                            model,
+                            reserved_cost_usd,
+                            status,
+                            expires_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """
+                );
+                PreparedStatement reservedQuery = connection.prepareStatement(
+                    "SELECT reserved_cost_usd FROM budget_monthly_usage WHERE scope_type = ? AND scope_id = ? AND year_month = ?"
+                )
+            ) {
+                usageInsert.setString(1, "WORKSPACE");
+                usageInsert.setLong(2, 7L);
+                usageInsert.setInt(3, 202603);
+                usageInsert.setBigDecimal(4, new java.math.BigDecimal("1.25"));
+                usageInsert.setLong(5, 500L);
+                usageInsert.setLong(6, 2L);
+                usageInsert.setBigDecimal(7, new java.math.BigDecimal("0.75"));
+                usageInsert.executeUpdate();
+
+                reservationInsert.setString(1, "trace-001");
+                reservationInsert.setString(2, "WORKSPACE");
+                reservationInsert.setLong(3, 7L);
+                reservationInsert.setInt(4, 202603);
+                reservationInsert.setString(5, "openai");
+                reservationInsert.setString(6, "gpt-4.1-mini");
+                reservationInsert.setBigDecimal(7, new java.math.BigDecimal("0.75"));
+                reservationInsert.setString(8, "RESERVED");
+                reservationInsert.setObject(9, OffsetDateTime.now().plusMinutes(1));
+                reservationInsert.executeUpdate();
+
+                // then
+                reservedQuery.setString(1, "WORKSPACE");
+                reservedQuery.setLong(2, 7L);
+                reservedQuery.setInt(3, 202603);
+
+                try (ResultSet resultSet = reservedQuery.executeQuery()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getBigDecimal(1)).isEqualByComparingTo("0.75");
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/BudgetReservationMigrationTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/BudgetReservationMigrationTest.java
@@ -26,11 +26,8 @@ class BudgetReservationMigrationTest {
         try (Connection connection = DriverManager.getConnection(url, "sa", "")) {
             ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource("db/migration/V19__budget_policies_and_usage.sql")));
 
-            // when
-            ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource("db/migration/V33__budget_reservations.sql")));
-
             try (
-                PreparedStatement usageInsert = connection.prepareStatement(
+                PreparedStatement existingUsageInsert = connection.prepareStatement(
                     """
                         INSERT INTO budget_monthly_usage (
                             scope_type,
@@ -38,9 +35,43 @@ class BudgetReservationMigrationTest {
                             year_month,
                             cost_usd,
                             total_tokens,
-                            request_count,
-                            reserved_cost_usd
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                            request_count
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """
+                )
+            ) {
+                existingUsageInsert.setString(1, "WORKSPACE");
+                existingUsageInsert.setLong(2, 7L);
+                existingUsageInsert.setInt(3, 202603);
+                existingUsageInsert.setBigDecimal(4, new java.math.BigDecimal("1.25"));
+                existingUsageInsert.setLong(5, 500L);
+                existingUsageInsert.setLong(6, 2L);
+                existingUsageInsert.executeUpdate();
+
+                // when
+                ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource("db/migration/V33__budget_reservations.sql")));
+
+                // then
+                try (PreparedStatement reservedQuery = connection.prepareStatement(
+                    "SELECT reserved_cost_usd FROM budget_monthly_usage WHERE scope_type = ? AND scope_id = ? AND year_month = ?"
+                )) {
+                    reservedQuery.setString(1, "WORKSPACE");
+                    reservedQuery.setLong(2, 7L);
+                    reservedQuery.setInt(3, 202603);
+
+                    try (ResultSet resultSet = reservedQuery.executeQuery()) {
+                        assertThat(resultSet.next()).isTrue();
+                        assertThat(resultSet.getBigDecimal(1)).isEqualByComparingTo("0");
+                    }
+                }
+            }
+
+            try (
+                PreparedStatement usageUpdate = connection.prepareStatement(
+                    """
+                        UPDATE budget_monthly_usage
+                        SET reserved_cost_usd = ?
+                        WHERE scope_type = ? AND scope_id = ? AND year_month = ?
                         """
                 );
                 PreparedStatement reservationInsert = connection.prepareStatement(
@@ -57,19 +88,13 @@ class BudgetReservationMigrationTest {
                             expires_at
                         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """
-                );
-                PreparedStatement reservedQuery = connection.prepareStatement(
-                    "SELECT reserved_cost_usd FROM budget_monthly_usage WHERE scope_type = ? AND scope_id = ? AND year_month = ?"
                 )
             ) {
-                usageInsert.setString(1, "WORKSPACE");
-                usageInsert.setLong(2, 7L);
-                usageInsert.setInt(3, 202603);
-                usageInsert.setBigDecimal(4, new java.math.BigDecimal("1.25"));
-                usageInsert.setLong(5, 500L);
-                usageInsert.setLong(6, 2L);
-                usageInsert.setBigDecimal(7, new java.math.BigDecimal("0.75"));
-                usageInsert.executeUpdate();
+                usageUpdate.setBigDecimal(1, new java.math.BigDecimal("0.75"));
+                usageUpdate.setString(2, "WORKSPACE");
+                usageUpdate.setLong(3, 7L);
+                usageUpdate.setInt(4, 202603);
+                usageUpdate.executeUpdate();
 
                 reservationInsert.setString(1, "trace-001");
                 reservationInsert.setString(2, "WORKSPACE");
@@ -81,16 +106,6 @@ class BudgetReservationMigrationTest {
                 reservationInsert.setString(8, "RESERVED");
                 reservationInsert.setObject(9, OffsetDateTime.now().plusMinutes(1));
                 reservationInsert.executeUpdate();
-
-                // then
-                reservedQuery.setString(1, "WORKSPACE");
-                reservedQuery.setLong(2, 7L);
-                reservedQuery.setInt(3, 202603);
-
-                try (ResultSet resultSet = reservedQuery.executeQuery()) {
-                    assertThat(resultSet.next()).isTrue();
-                    assertThat(resultSet.getBigDecimal(1)).isEqualByComparingTo("0.75");
-                }
             }
         }
     }

--- a/src/test/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepositoryTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepositoryTest.java
@@ -188,7 +188,7 @@ class BudgetMonthlyUsageRepositoryTest {
             Future<Integer> first = executorService.submit(() -> reserveConcurrently(yearMonth, ready, start));
             Future<Integer> second = executorService.submit(() -> reserveConcurrently(yearMonth, ready, start));
 
-            ready.await(5, TimeUnit.SECONDS);
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
 
             // when
             start.countDown();

--- a/src/test/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepositoryTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/repository/BudgetMonthlyUsageRepositoryTest.java
@@ -1,0 +1,231 @@
+package com.llm_ops.demo.budget.repository;
+
+import com.llm_ops.demo.budget.domain.BudgetMonthlyUsage;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BudgetMonthlyUsageRepositoryTest {
+
+    @Autowired
+    private BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @AfterEach
+    void tearDown() {
+        budgetMonthlyUsageRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("ensureUsageRow를 호출하면 usage row를 생성한다")
+    void ensureUsageRow를_호출하면_usage_row를_생성한다() {
+        // given
+        Integer yearMonth = 202603;
+
+        // when
+        int inserted = executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(
+            BudgetScopeType.WORKSPACE.name(),
+            7L,
+            yearMonth
+        ));
+
+        // then
+        assertThat(inserted).isEqualTo(1);
+        BudgetMonthlyUsage usage = budgetMonthlyUsageRepository
+            .findByScopeTypeAndScopeIdAndYearMonth(BudgetScopeType.WORKSPACE, 7L, yearMonth)
+            .orElseThrow();
+        assertThat(usage.getReservedCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("reserveCostIfWithinLimit는 한도 내이면 1을 반환한다")
+    void reserveCostIfWithinLimit는_한도_내이면_1을_반환한다() {
+        // given
+        Integer yearMonth = 202603;
+        executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(BudgetScopeType.WORKSPACE.name(), 7L, yearMonth));
+
+        // when
+        int updated = executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.WORKSPACE.name(),
+            7L,
+            yearMonth,
+            new BigDecimal("0.80"),
+            new BigDecimal("1.00")
+        ));
+
+        // then
+        assertThat(updated).isEqualTo(1);
+        assertThat(budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(BudgetScopeType.WORKSPACE, 7L, yearMonth))
+            .isPresent()
+            .get()
+            .extracting(BudgetMonthlyUsage::getReservedCostUsd)
+            .isEqualTo(new BigDecimal("0.80000000"));
+    }
+
+    @Test
+    @DisplayName("reserveCostIfWithinLimit는 한도 초과이면 0을 반환한다")
+    void reserveCostIfWithinLimit는_한도_초과이면_0을_반환한다() {
+        // given
+        Integer yearMonth = 202603;
+        executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 11L, yearMonth));
+        executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.PROVIDER_CREDENTIAL.name(),
+            11L,
+            yearMonth,
+            new BigDecimal("0.90"),
+            new BigDecimal("1.00")
+        ));
+
+        // when
+        int updated = executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.PROVIDER_CREDENTIAL.name(),
+            11L,
+            yearMonth,
+            new BigDecimal("0.20"),
+            new BigDecimal("1.00")
+        ));
+
+        // then
+        assertThat(updated).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("settleReservation은 reserved를 차감하고 spent를 증가시킨다")
+    void settleReservation은_reserved를_차감하고_spent를_증가시킨다() {
+        // given
+        Integer yearMonth = 202603;
+        executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(BudgetScopeType.WORKSPACE.name(), 9L, yearMonth));
+        executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.WORKSPACE.name(),
+            9L,
+            yearMonth,
+            new BigDecimal("0.70"),
+            new BigDecimal("5.00")
+        ));
+
+        // when
+        int updated = executeInTransaction(() -> budgetMonthlyUsageRepository.settleReservation(
+            BudgetScopeType.WORKSPACE.name(),
+            9L,
+            yearMonth,
+            new BigDecimal("0.70"),
+            new BigDecimal("0.42"),
+            777L,
+            1L
+        ));
+
+        // then
+        assertThat(updated).isEqualTo(1);
+        BudgetMonthlyUsage usage = budgetMonthlyUsageRepository
+            .findByScopeTypeAndScopeIdAndYearMonth(BudgetScopeType.WORKSPACE, 9L, yearMonth)
+            .orElseThrow();
+        assertThat(usage.getReservedCostUsd()).isEqualByComparingTo("0.00000000");
+        assertThat(usage.getCostUsd()).isEqualByComparingTo("0.42000000");
+        assertThat(usage.getTotalTokens()).isEqualTo(777L);
+        assertThat(usage.getRequestCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("releaseReservedCost는 reserved를 차감한다")
+    void releaseReservedCost는_reserved를_차감한다() {
+        // given
+        Integer yearMonth = 202603;
+        executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 15L, yearMonth));
+        executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.PROVIDER_CREDENTIAL.name(),
+            15L,
+            yearMonth,
+            new BigDecimal("0.55"),
+            new BigDecimal("1.00")
+        ));
+
+        // when
+        int updated = executeInTransaction(() -> budgetMonthlyUsageRepository.releaseReservedCost(
+            BudgetScopeType.PROVIDER_CREDENTIAL.name(),
+            15L,
+            yearMonth,
+            new BigDecimal("0.55")
+        ));
+
+        // then
+        assertThat(updated).isEqualTo(1);
+        assertThat(budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(BudgetScopeType.PROVIDER_CREDENTIAL, 15L, yearMonth))
+            .isPresent()
+            .get()
+            .extracting(BudgetMonthlyUsage::getReservedCostUsd)
+            .isEqualTo(new BigDecimal("0.00000000"));
+    }
+
+    @Test
+    @DisplayName("동시에 reserve 두 건이 들어오면 한 건만 성공한다")
+    void 동시에_reserve_두_건이_들어오면_한_건만_성공한다() throws Exception {
+        // given
+        Integer yearMonth = 202603;
+        executeInTransaction(() -> budgetMonthlyUsageRepository.ensureUsageRow(BudgetScopeType.WORKSPACE.name(), 19L, yearMonth));
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            Future<Integer> first = executorService.submit(() -> reserveConcurrently(yearMonth, ready, start));
+            Future<Integer> second = executorService.submit(() -> reserveConcurrently(yearMonth, ready, start));
+
+            ready.await(5, TimeUnit.SECONDS);
+
+            // when
+            start.countDown();
+            int firstResult = first.get(5, TimeUnit.SECONDS);
+            int secondResult = second.get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(firstResult + secondResult).isEqualTo(1);
+            assertThat(budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(BudgetScopeType.WORKSPACE, 19L, yearMonth))
+                .isPresent()
+                .get()
+                .extracting(BudgetMonthlyUsage::getReservedCostUsd)
+                .isEqualTo(new BigDecimal("0.60000000"));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private int reserveConcurrently(Integer yearMonth, CountDownLatch ready, CountDownLatch start) throws Exception {
+        ready.countDown();
+        start.await(5, TimeUnit.SECONDS);
+        return executeInTransaction(() -> budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            BudgetScopeType.WORKSPACE.name(),
+            19L,
+            yearMonth,
+            new BigDecimal("0.60"),
+            new BigDecimal("1.00")
+        ));
+    }
+
+    private <T> T executeInTransaction(TransactionCallback<T> callback) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        return transactionTemplate.execute(status -> callback.run());
+    }
+
+    @FunctionalInterface
+    private interface TransactionCallback<T> {
+        T run();
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/repository/BudgetReservationRepositoryTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/repository/BudgetReservationRepositoryTest.java
@@ -13,11 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class BudgetReservationRepositoryTest {
 
     @Autowired
@@ -115,5 +117,70 @@ class BudgetReservationRepositoryTest {
         // then
         assertThat(staleReservations).hasSize(1);
         assertThat(staleReservations.get(0).getTraceId()).isEqualTo("trace-old");
+    }
+
+    @Test
+    @DisplayName("RESERVED reservation은 조건부 정산 상태 전이가 한 번만 성공한다")
+    void RESERVED_reservation은_조건부_정산_상태_전이가_한_번만_성공한다() {
+        // given
+        BudgetReservation reservation = budgetReservationRepository.save(BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-settle-transition",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            40L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.50"),
+            200,
+            128,
+            LocalDateTime.now().plusMinutes(1)
+        ));
+
+        // when
+        int firstTransition = budgetReservationRepository.markSettledIfReserved(
+            reservation.getId(),
+            new BigDecimal("0.32")
+        );
+        int secondTransition = budgetReservationRepository.markSettledIfReserved(
+            reservation.getId(),
+            new BigDecimal("0.32")
+        );
+
+        // then
+        BudgetReservation settled = budgetReservationRepository.findById(reservation.getId()).orElseThrow();
+        assertThat(firstTransition).isEqualTo(1);
+        assertThat(secondTransition).isEqualTo(0);
+        assertThat(settled.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
+        assertThat(settled.getSettledCostUsd()).isEqualByComparingTo(new BigDecimal("0.32"));
+    }
+
+    @Test
+    @DisplayName("이미 종료된 reservation은 조건부 반환 상태 전이가 실패한다")
+    void 이미_종료된_reservation은_조건부_반환_상태_전이가_실패한다() {
+        // given
+        BudgetReservation reservation = budgetReservationRepository.save(BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-release-transition",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            41L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.45"),
+            200,
+            128,
+            LocalDateTime.now().plusMinutes(1)
+        ));
+        budgetReservationRepository.markReleasedIfReserved(reservation.getId(), "TEST_RELEASE");
+
+        // when
+        int transition = budgetReservationRepository.markReleasedIfReserved(reservation.getId(), "TEST_RELEASE");
+
+        // then
+        BudgetReservation released = budgetReservationRepository.findById(reservation.getId()).orElseThrow();
+        assertThat(transition).isEqualTo(0);
+        assertThat(released.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
+        assertThat(released.getReleaseReason()).isEqualTo("TEST_RELEASE");
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/repository/BudgetReservationRepositoryTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/repository/BudgetReservationRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.llm_ops.demo.budget.repository;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BudgetReservationRepositoryTest {
+
+    @Autowired
+    private BudgetReservationRepository budgetReservationRepository;
+
+    @AfterEach
+    void tearDown() {
+        budgetReservationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("traceId와 scope로 reservation을 조회한다")
+    void traceId와_scope로_reservation을_조회한다() {
+        // given
+        BudgetReservation reservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-lookup",
+            BudgetScopeType.WORKSPACE,
+            30L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.30"),
+            1000,
+            256,
+            LocalDateTime.now().plusMinutes(1)
+        );
+        budgetReservationRepository.save(reservation);
+
+        // when
+        var result = budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(
+            "trace-lookup",
+            BudgetScopeType.WORKSPACE,
+            30L
+        );
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getModel()).isEqualTo("gpt-4.1-mini");
+    }
+
+    @Test
+    @DisplayName("만료 시각 이전 RESERVED reservation만 조회한다")
+    void 만료_시각_이전_RESERVED_reservation만_조회한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        budgetReservationRepository.save(BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-old",
+            BudgetScopeType.WORKSPACE,
+            30L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.30"),
+            1000,
+            256,
+            now.minusMinutes(1)
+        ));
+
+        BudgetReservation releasedReservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-released",
+            BudgetScopeType.WORKSPACE,
+            31L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.30"),
+            1000,
+            256,
+            now.minusMinutes(2)
+        );
+        releasedReservation.markReleased("TEST");
+        budgetReservationRepository.save(releasedReservation);
+
+        budgetReservationRepository.save(BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-future",
+            BudgetScopeType.WORKSPACE,
+            32L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.30"),
+            1000,
+            256,
+            now.plusMinutes(1)
+        ));
+
+        // when
+        List<BudgetReservation> staleReservations = budgetReservationRepository
+            .findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(BudgetReservationStatus.RESERVED, now);
+
+        // then
+        assertThat(staleReservations).hasSize(1);
+        assertThat(staleReservations.get(0).getTraceId()).isEqualTo("trace-old");
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetGuardrailServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetGuardrailServiceTest.java
@@ -85,6 +85,31 @@ class BudgetGuardrailServiceTest {
     }
 
     @Test
+    @DisplayName("Provider credential 예약 금액까지 합산해 하드리밋 이상이면 BLOCK을 반환한다")
+    void provider_예약_금액까지_합산해_하드리밋_이상이면_BLOCK을_반환한다() {
+        // given
+        Long credentialId = 10L;
+        YearMonth ym = YearMonth.of(2026, 2);
+        BudgetPolicy policy = BudgetPolicy.createDefault(BudgetScopeType.PROVIDER_CREDENTIAL, credentialId);
+        policy.update(new BigDecimal("50.00"), null, null, null, null, null, true);
+        BudgetMonthlyUsage usage = BudgetMonthlyUsage.create(BudgetScopeType.PROVIDER_CREDENTIAL, credentialId, 202602);
+        usage.addUsage(new BigDecimal("49.60"), 100L, 1L);
+        usage.reserveCost(new BigDecimal("0.50"));
+
+        when(budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, credentialId))
+            .thenReturn(Optional.of(policy));
+        when(budgetUsageService.currentUtcYearMonth()).thenReturn(ym);
+        when(budgetUsageService.findUsage(BudgetScopeType.PROVIDER_CREDENTIAL, credentialId, ym))
+            .thenReturn(Optional.of(usage));
+
+        // when
+        BudgetDecision decision = budgetGuardrailService.evaluateProviderCredential(credentialId);
+
+        // then
+        assertThat(decision.action()).isEqualTo(BudgetDecisionAction.BLOCK);
+    }
+
+    @Test
     @DisplayName("Workspace 월 사용량이 soft-limit 이상이면 DEGRADE를 반환한다")
     void workspace_월_사용량이_soft_limit_이상이면_DEGRADE를_반환한다() {
         // given
@@ -140,6 +165,33 @@ class BudgetGuardrailServiceTest {
         // then
         assertThat(decision.action()).isEqualTo(BudgetDecisionAction.ALLOW);
         verify(budgetPolicyService, never()).parseDegradeProviderModelMapOrEmpty(eq(policy));
+    }
+
+    @Test
+    @DisplayName("Workspace 예약 금액까지 합산해 soft-limit 이상이면 DEGRADE를 반환한다")
+    void workspace_예약_금액까지_합산해_soft_limit_이상이면_DEGRADE를_반환한다() {
+        // given
+        Long workspaceId = 7L;
+        YearMonth ym = YearMonth.of(2026, 2);
+        BudgetPolicy policy = BudgetPolicy.createDefault(BudgetScopeType.WORKSPACE, workspaceId);
+        policy.update(null, new BigDecimal("10.00"), BudgetSoftAction.DEGRADE, "{}", 256, false, true);
+        BudgetMonthlyUsage usage = BudgetMonthlyUsage.create(BudgetScopeType.WORKSPACE, workspaceId, 202602);
+        usage.addUsage(new BigDecimal("9.80"), 500L, 2L);
+        usage.reserveCost(new BigDecimal("0.30"));
+
+        when(budgetPolicyService.findPolicy(BudgetScopeType.WORKSPACE, workspaceId))
+            .thenReturn(Optional.of(policy));
+        when(budgetUsageService.currentUtcYearMonth()).thenReturn(ym);
+        when(budgetUsageService.findUsage(BudgetScopeType.WORKSPACE, workspaceId, ym))
+            .thenReturn(Optional.of(usage));
+        when(budgetPolicyService.parseDegradeProviderModelMapOrEmpty(policy))
+            .thenReturn(Map.of("openai", "gpt-4o-mini"));
+
+        // when
+        BudgetDecision decision = budgetGuardrailService.evaluateWorkspaceDegrade(workspaceId, "openai");
+
+        // then
+        assertThat(decision.action()).isEqualTo(BudgetDecisionAction.DEGRADE);
     }
 
     @Test

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationEstimatorTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationEstimatorTest.java
@@ -1,0 +1,125 @@
+package com.llm_ops.demo.budget.service;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+import com.llm_ops.demo.budget.config.BudgetReservationEstimationProperties;
+import com.llm_ops.demo.gateway.pricing.ModelPricing;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BudgetReservationEstimatorTest {
+
+    private final EncodingRegistry registry = Encodings.newLazyEncodingRegistry();
+    private final Encoding encoding = registry.getEncoding(EncodingType.CL100K_BASE);
+
+    @Test
+    @DisplayName("알려진 모델과 effective maxTokens가 있으면 최대 비용 상한을 계산한다")
+    void 알려진_모델과_effective_maxTokens가_있으면_최대_비용_상한을_계산한다() {
+        // given
+        BudgetReservationEstimationProperties properties = new BudgetReservationEstimationProperties();
+        properties.setInputTokenSafetyMultiplier(new BigDecimal("1.10"));
+        BudgetReservationEstimator estimator = new BudgetReservationEstimator(properties);
+        String systemPrompt = "You are a helpful assistant.";
+        String userPrompt = "Summarize the budget reservation design in one paragraph.";
+        int rawInputTokens = encoding.countTokens(systemPrompt) + encoding.countTokens(userPrompt);
+        int expectedInputTokens = BigDecimal.valueOf(rawInputTokens)
+            .multiply(new BigDecimal("1.10"))
+            .setScale(0, RoundingMode.CEILING)
+            .intValueExact();
+
+        // when
+        BudgetReservationEstimate estimate = estimator.estimate(
+            "gpt-4.1-mini",
+            systemPrompt,
+            userPrompt,
+            512
+        );
+
+        // then
+        assertThat(estimate.reservable()).isTrue();
+        assertThat(estimate.pricingModel()).isEqualTo("gpt-4.1-mini");
+        assertThat(estimate.reservedInputTokens()).isEqualTo(expectedInputTokens);
+        assertThat(estimate.reservedOutputTokens()).isEqualTo(512);
+        assertThat(estimate.reserveAmountUsd())
+            .isEqualByComparingTo(ModelPricing.calculateCost("gpt-4.1-mini", expectedInputTokens, 512));
+        assertThat(estimate.rejectionReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("effective maxTokens가 없으면 기본 출력 토큰 상한을 사용한다")
+    void effective_maxTokens가_없으면_기본_출력_토큰_상한을_사용한다() {
+        // given
+        BudgetReservationEstimationProperties properties = new BudgetReservationEstimationProperties();
+        properties.setDefaultMaxOutputTokens(1024);
+        BudgetReservationEstimator estimator = new BudgetReservationEstimator(properties);
+
+        // when
+        BudgetReservationEstimate estimate = estimator.estimate(
+            "gpt-4.1-mini",
+            "System prompt",
+            "User prompt",
+            null
+        );
+
+        // then
+        assertThat(estimate.reservable()).isTrue();
+        assertThat(estimate.reservedOutputTokens()).isEqualTo(1024);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 모델이면 예약 불가 결과를 반환한다")
+    void 알_수_없는_모델이면_예약_불가_결과를_반환한다() {
+        // given
+        BudgetReservationEstimator estimator = new BudgetReservationEstimator(new BudgetReservationEstimationProperties());
+
+        // when
+        BudgetReservationEstimate estimate = estimator.estimate(
+            "unknown-model",
+            "System prompt",
+            "User prompt",
+            256
+        );
+
+        // then
+        assertThat(estimate.reservable()).isFalse();
+        assertThat(estimate.rejectionReason()).isEqualTo(BudgetReservationEstimator.PRICING_UNAVAILABLE_REASON);
+        assertThat(estimate.reserveAmountUsd()).isNull();
+        assertThat(estimate.reservedInputTokens()).isNull();
+        assertThat(estimate.reservedOutputTokens()).isNull();
+    }
+
+    @Test
+    @DisplayName("설정값이 비정상이면 기본 안전계수와 기본 출력 토큰 상한을 사용한다")
+    void 설정값이_비정상이면_기본_안전계수와_기본_출력_토큰_상한을_사용한다() {
+        // given
+        BudgetReservationEstimationProperties properties = new BudgetReservationEstimationProperties();
+        properties.setInputTokenSafetyMultiplier(new BigDecimal("0.50"));
+        properties.setDefaultMaxOutputTokens(0);
+        BudgetReservationEstimator estimator = new BudgetReservationEstimator(properties);
+        String userPrompt = "Fallback defaults should be applied.";
+        int rawInputTokens = encoding.countTokens(userPrompt);
+        int expectedInputTokens = BigDecimal.valueOf(rawInputTokens)
+            .multiply(new BigDecimal("1.10"))
+            .setScale(0, RoundingMode.CEILING)
+            .intValueExact();
+
+        // when
+        BudgetReservationEstimate estimate = estimator.estimate(
+            "gpt-4.1-mini",
+            null,
+            userPrompt,
+            -1
+        );
+
+        // then
+        assertThat(estimate.reservable()).isTrue();
+        assertThat(estimate.reservedInputTokens()).isEqualTo(expectedInputTokens);
+        assertThat(estimate.reservedOutputTokens()).isEqualTo(2048);
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationMetricsTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationMetricsTest.java
@@ -1,0 +1,50 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BudgetReservationMetricsTest {
+
+    @Test
+    @DisplayName("reservation 메트릭을 이름과 태그 기준으로 누적한다")
+    void reservation_메트릭을_이름과_태그_기준으로_누적한다() {
+        // given
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        BudgetReservationMetrics metrics = new BudgetReservationMetrics(registry);
+
+        // when
+        metrics.incrementReserve(BudgetScopeType.PROVIDER_CREDENTIAL);
+        metrics.incrementReserveFailed(BudgetScopeType.PROVIDER_CREDENTIAL, "LIMIT_EXCEEDED");
+        metrics.incrementSettle(BudgetScopeType.PROVIDER_CREDENTIAL);
+        metrics.incrementRelease(BudgetScopeType.PROVIDER_CREDENTIAL, "PRIMARY_ROUTE_FAILED");
+        metrics.incrementExpired(BudgetScopeType.PROVIDER_CREDENTIAL);
+
+        // then
+        assertThat(registry.get("gateway_budget_reserve_total")
+            .tag("scope_type", "provider_credential")
+            .counter()
+            .count()).isEqualTo(1.0);
+        assertThat(registry.get("gateway_budget_reserve_failed_total")
+            .tag("scope_type", "provider_credential")
+            .tag("reason", "LIMIT_EXCEEDED")
+            .counter()
+            .count()).isEqualTo(1.0);
+        assertThat(registry.get("gateway_budget_settle_total")
+            .tag("scope_type", "provider_credential")
+            .counter()
+            .count()).isEqualTo(1.0);
+        assertThat(registry.get("gateway_budget_release_total")
+            .tag("scope_type", "provider_credential")
+            .tag("reason", "PRIMARY_ROUTE_FAILED")
+            .counter()
+            .count()).isEqualTo(1.0);
+        assertThat(registry.get("gateway_budget_reservation_expired_total")
+            .tag("scope_type", "provider_credential")
+            .counter()
+            .count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationRecoveryJobTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationRecoveryJobTest.java
@@ -1,0 +1,32 @@
+package com.llm_ops.demo.budget.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetReservationRecoveryJobTest {
+
+    @Mock
+    private BudgetReservationService budgetReservationService;
+
+    @InjectMocks
+    private BudgetReservationRecoveryJob budgetReservationRecoveryJob;
+
+    @Test
+    @DisplayName("스케줄러가 실행되면 stale reservation 복구를 위임한다")
+    void 스케줄러가_실행되면_stale_reservation_복구를_위임한다() {
+        // given
+
+        // when
+        budgetReservationRecoveryJob.expireStaleReservations();
+
+        // then
+        verify(budgetReservationService).expireStaleReservations();
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.llm_ops.demo.budget.service;
 
+import com.llm_ops.demo.budget.domain.BudgetMonthlyUsage;
 import com.llm_ops.demo.budget.domain.BudgetReservation;
 import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
 import com.llm_ops.demo.budget.domain.BudgetScopeType;
@@ -115,6 +116,47 @@ class BudgetReservationServiceConcurrencyTest {
         assertThat(released.getReleaseReason()).isEqualTo("TEST_RELEASE");
     }
 
+    @Test
+    @DisplayName("settle과 release가 동시에 실행돼도 reservation은 한 번만 최종 처리된다")
+    void settle과_release가_동시에_실행돼도_reservation은_한_번만_최종_처리된다() throws Exception {
+        // given
+        BudgetReservation reservation = reserveSingle("trace-settle-release-race", 33L, new BigDecimal("1.00"), new BigDecimal("0.40"));
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Void> settleFuture = executorService.submit(() -> {
+                ready.countDown();
+                start.await(5, TimeUnit.SECONDS);
+                budgetReservationService.settle(reservation.getId(), new BigDecimal("0.18"), 123L);
+                return null;
+            });
+            Future<Void> releaseFuture = executorService.submit(() -> {
+                ready.countDown();
+                start.await(5, TimeUnit.SECONDS);
+                budgetReservationService.release(reservation.getId(), "TEST_RACE");
+                return null;
+            });
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+
+            // when
+            start.countDown();
+            settleFuture.get(5, TimeUnit.SECONDS);
+            releaseFuture.get(5, TimeUnit.SECONDS);
+
+            // then
+            BudgetReservation finalizedReservation = budgetReservationRepository.findById(reservation.getId()).orElseThrow();
+            assertThat(finalizedReservation.getStatus())
+                .isIn(BudgetReservationStatus.SETTLED, BudgetReservationStatus.RELEASED);
+
+            assertUsageMatchesTerminalState(finalizedReservation, 33L);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
     private Optional<BudgetReservation> reserveConcurrently(
         String traceId,
         YearMonth yearMonth,
@@ -159,5 +201,28 @@ class BudgetReservationServiceConcurrencyTest {
             256,
             Duration.ofSeconds(60)
         ).orElseThrow();
+    }
+
+    private void assertUsageMatchesTerminalState(BudgetReservation finalizedReservation, Long scopeId) {
+        BudgetMonthlyUsage usage = budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            scopeId,
+            202603
+        ).orElseThrow();
+
+        assertThat(usage.getReservedCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+
+        if (finalizedReservation.getStatus() == BudgetReservationStatus.SETTLED) {
+            assertThat(finalizedReservation.getSettledCostUsd()).isEqualByComparingTo(new BigDecimal("0.18"));
+            assertThat(usage.getCostUsd()).isEqualByComparingTo(new BigDecimal("0.18"));
+            assertThat(usage.getTotalTokens()).isEqualTo(123L);
+            assertThat(usage.getRequestCount()).isEqualTo(1L);
+            return;
+        }
+
+        assertThat(finalizedReservation.getReleaseReason()).isEqualTo("TEST_RACE");
+        assertThat(usage.getCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(usage.getTotalTokens()).isEqualTo(0L);
+        assertThat(usage.getRequestCount()).isEqualTo(0L);
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.llm_ops.demo.budget.service;
 
 import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
 import com.llm_ops.demo.budget.domain.BudgetScopeType;
 import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
 import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
@@ -84,6 +85,36 @@ class BudgetReservationServiceConcurrencyTest {
         }
     }
 
+    @Test
+    @DisplayName("settle 이후 reservation 상태가 SETTLED로 저장된다")
+    void settle_이후_reservation_상태가_SETTLED로_저장된다() {
+        // given
+        BudgetReservation reservation = reserveSingle("trace-settle", 31L, new BigDecimal("1.00"), new BigDecimal("0.40"));
+
+        // when
+        budgetReservationService.settle(reservation.getId(), BigDecimal.ZERO, 0L);
+
+        // then
+        BudgetReservation settled = budgetReservationRepository.findById(reservation.getId()).orElseThrow();
+        assertThat(settled.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
+        assertThat(settled.getSettledCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("release 이후 reservation 상태가 RELEASED로 저장된다")
+    void release_이후_reservation_상태가_RELEASED로_저장된다() {
+        // given
+        BudgetReservation reservation = reserveSingle("trace-release", 32L, new BigDecimal("1.00"), new BigDecimal("0.40"));
+
+        // when
+        budgetReservationService.release(reservation.getId(), "TEST_RELEASE");
+
+        // then
+        BudgetReservation released = budgetReservationRepository.findById(reservation.getId()).orElseThrow();
+        assertThat(released.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
+        assertThat(released.getReleaseReason()).isEqualTo("TEST_RELEASE");
+    }
+
     private Optional<BudgetReservation> reserveConcurrently(
         String traceId,
         YearMonth yearMonth,
@@ -106,5 +137,27 @@ class BudgetReservationServiceConcurrencyTest {
             256,
             Duration.ofSeconds(60)
         );
+    }
+
+    private BudgetReservation reserveSingle(
+        String traceId,
+        Long scopeId,
+        BigDecimal monthLimitUsd,
+        BigDecimal reserveAmount
+    ) {
+        return budgetReservationService.reserve(
+            UUID.randomUUID(),
+            traceId,
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            scopeId,
+            YearMonth.of(2026, 3),
+            monthLimitUsd,
+            reserveAmount,
+            "openai",
+            "gpt-4.1-mini",
+            100,
+            256,
+            Duration.ofSeconds(60)
+        ).orElseThrow();
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
@@ -1,0 +1,110 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.YearMonth;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BudgetReservationServiceConcurrencyTest {
+
+    @Autowired
+    private BudgetReservationService budgetReservationService;
+
+    @Autowired
+    private BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+
+    @Autowired
+    private BudgetReservationRepository budgetReservationRepository;
+
+    @AfterEach
+    void tearDown() {
+        budgetReservationRepository.deleteAll();
+        budgetMonthlyUsageRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동시에 reserve 두 건이 들어오면 한 건만 reservation을 생성한다")
+    void 동시에_reserve_두_건이_들어오면_한_건만_reservation을_생성한다() throws Exception {
+        // given
+        YearMonth yearMonth = YearMonth.of(2026, 3);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Optional<BudgetReservation>> first = executorService.submit(() ->
+                reserveConcurrently("trace-concurrency-1", yearMonth, ready, start)
+            );
+            Future<Optional<BudgetReservation>> second = executorService.submit(() ->
+                reserveConcurrently("trace-concurrency-2", yearMonth, ready, start)
+            );
+
+            ready.await(5, TimeUnit.SECONDS);
+
+            // when
+            start.countDown();
+            Optional<BudgetReservation> firstResult = first.get(5, TimeUnit.SECONDS);
+            Optional<BudgetReservation> secondResult = second.get(5, TimeUnit.SECONDS);
+
+            // then
+            long successCount = java.util.stream.Stream.of(firstResult, secondResult)
+                .filter(Optional::isPresent)
+                .count();
+            assertThat(successCount).isEqualTo(1);
+            assertThat(budgetReservationRepository.findAll()).hasSize(1);
+            assertThat(budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(
+                BudgetScopeType.PROVIDER_CREDENTIAL,
+                21L,
+                202603
+            )).isPresent().get()
+                .extracting(usage -> usage.getReservedCostUsd())
+                .isEqualTo(new BigDecimal("0.60000000"));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private Optional<BudgetReservation> reserveConcurrently(
+        String traceId,
+        YearMonth yearMonth,
+        CountDownLatch ready,
+        CountDownLatch start
+    ) throws Exception {
+        ready.countDown();
+        start.await(5, TimeUnit.SECONDS);
+        return budgetReservationService.reserve(
+            UUID.randomUUID(),
+            traceId,
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            21L,
+            yearMonth,
+            new BigDecimal("1.00"),
+            new BigDecimal("0.60"),
+            "openai",
+            "gpt-4.1-mini",
+            100,
+            256,
+            Duration.ofSeconds(60)
+        );
+    }
+}

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceConcurrencyTest.java
@@ -55,10 +55,10 @@ class BudgetReservationServiceConcurrencyTest {
 
         try {
             Future<Optional<BudgetReservation>> first = executorService.submit(() ->
-                reserveConcurrently("trace-concurrency-1", yearMonth, ready, start)
+                reserveConcurrently("trace-concurrency-1", 21L, yearMonth, new BigDecimal("1.00"), ready, start)
             );
             Future<Optional<BudgetReservation>> second = executorService.submit(() ->
-                reserveConcurrently("trace-concurrency-2", yearMonth, ready, start)
+                reserveConcurrently("trace-concurrency-2", 21L, yearMonth, new BigDecimal("1.00"), ready, start)
             );
 
             ready.await(5, TimeUnit.SECONDS);
@@ -80,6 +80,47 @@ class BudgetReservationServiceConcurrencyTest {
                 202603
             )).isPresent().get()
                 .extracting(usage -> usage.getReservedCostUsd())
+                .isEqualTo(new BigDecimal("0.60000000"));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("동시에 같은 traceId reserve가 들어오면 기존 reservation을 재사용한다")
+    void 동시에_같은_traceId_reserve가_들어오면_기존_reservation을_재사용한다() throws Exception {
+        // given
+        YearMonth yearMonth = YearMonth.of(2026, 3);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Optional<BudgetReservation>> first = executorService.submit(() ->
+                reserveConcurrently("trace-duplicate", 22L, yearMonth, new BigDecimal("2.00"), ready, start)
+            );
+            Future<Optional<BudgetReservation>> second = executorService.submit(() ->
+                reserveConcurrently("trace-duplicate", 22L, yearMonth, new BigDecimal("2.00"), ready, start)
+            );
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+
+            // when
+            start.countDown();
+            Optional<BudgetReservation> firstResult = first.get(5, TimeUnit.SECONDS);
+            Optional<BudgetReservation> secondResult = second.get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(firstResult).isPresent();
+            assertThat(secondResult).isPresent();
+            assertThat(firstResult.get().getId()).isEqualTo(secondResult.get().getId());
+            assertThat(budgetReservationRepository.findAll()).hasSize(1);
+            assertThat(budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(
+                BudgetScopeType.PROVIDER_CREDENTIAL,
+                22L,
+                202603
+            )).isPresent().get()
+                .extracting(BudgetMonthlyUsage::getReservedCostUsd)
                 .isEqualTo(new BigDecimal("0.60000000"));
         } finally {
             executorService.shutdownNow();
@@ -159,7 +200,9 @@ class BudgetReservationServiceConcurrencyTest {
 
     private Optional<BudgetReservation> reserveConcurrently(
         String traceId,
+        Long scopeId,
         YearMonth yearMonth,
+        BigDecimal monthLimitUsd,
         CountDownLatch ready,
         CountDownLatch start
     ) throws Exception {
@@ -169,9 +212,9 @@ class BudgetReservationServiceConcurrencyTest {
             UUID.randomUUID(),
             traceId,
             BudgetScopeType.PROVIDER_CREDENTIAL,
-            21L,
+            scopeId,
             yearMonth,
-            new BigDecimal("1.00"),
+            monthLimitUsd,
             new BigDecimal("0.60"),
             "openai",
             "gpt-4.1-mini",

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -34,6 +34,9 @@ class BudgetReservationServiceTest {
     @Mock
     private BudgetReservationRepository budgetReservationRepository;
 
+    @Mock
+    private BudgetReservationMetrics budgetReservationMetrics;
+
     @InjectMocks
     private BudgetReservationService budgetReservationService;
 
@@ -79,6 +82,7 @@ class BudgetReservationServiceTest {
         assertThat(result.get().getStatus()).isEqualTo(BudgetReservationStatus.RESERVED);
         assertThat(result.get().getReservedCostUsd()).isEqualByComparingTo(reserveAmount);
         verify(budgetMonthlyUsageRepository).ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 10L, 202603);
+        verify(budgetReservationMetrics).incrementReserve(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 
     @Test
@@ -111,6 +115,7 @@ class BudgetReservationServiceTest {
 
         // then
         assertThat(result).isEmpty();
+        verify(budgetReservationMetrics).incrementReserveFailed(BudgetScopeType.WORKSPACE, "LIMIT_EXCEEDED");
     }
 
     @Test
@@ -148,6 +153,7 @@ class BudgetReservationServiceTest {
         // then
         assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
         assertThat(reservation.getSettledCostUsd()).isEqualByComparingTo("0.42");
+        verify(budgetReservationMetrics).incrementSettle(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 
     @Test
@@ -182,6 +188,7 @@ class BudgetReservationServiceTest {
         // then
         assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
         assertThat(reservation.getReleaseReason()).isEqualTo("PRIMARY_ROUTE_FAILED");
+        verify(budgetReservationMetrics).incrementRelease(BudgetScopeType.WORKSPACE, "PRIMARY_ROUTE_FAILED");
     }
 
     @Test
@@ -219,5 +226,6 @@ class BudgetReservationServiceTest {
         assertThat(expiredCount).isEqualTo(1);
         assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.EXPIRED);
         assertThat(reservation.getReleaseReason()).isEqualTo("RESERVATION_EXPIRED");
+        verify(budgetReservationMetrics).incrementExpired(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -35,6 +35,9 @@ class BudgetReservationServiceTest {
     private BudgetReservationRepository budgetReservationRepository;
 
     @Mock
+    private BudgetUsageRowInitializer budgetUsageRowInitializer;
+
+    @Mock
     private BudgetReservationMetrics budgetReservationMetrics;
 
     @InjectMocks
@@ -81,7 +84,7 @@ class BudgetReservationServiceTest {
         assertThat(result.get().getTraceId()).isEqualTo(traceId);
         assertThat(result.get().getStatus()).isEqualTo(BudgetReservationStatus.RESERVED);
         assertThat(result.get().getReservedCostUsd()).isEqualByComparingTo(reserveAmount);
-        verify(budgetMonthlyUsageRepository).ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 10L, 202603);
+        verify(budgetUsageRowInitializer).ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 10L, 202603);
         verify(budgetReservationMetrics).incrementReserve(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -7,7 +7,9 @@ import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
 import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -180,5 +182,42 @@ class BudgetReservationServiceTest {
         // then
         assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
         assertThat(reservation.getReleaseReason()).isEqualTo("PRIMARY_ROUTE_FAILED");
+    }
+
+    @Test
+    @DisplayName("만료된 reservation이 있으면 EXPIRED로 복구한다")
+    void 만료된_reservation이_있으면_EXPIRED로_복구한다() {
+        // given
+        BudgetReservation reservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-expired",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            12L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.33"),
+            700,
+            256,
+            LocalDateTime.now().minusMinutes(1)
+        );
+        when(budgetReservationRepository.findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
+            eq(BudgetReservationStatus.RESERVED),
+            any(LocalDateTime.class)
+        )).thenReturn(List.of(reservation));
+        when(budgetMonthlyUsageRepository.releaseReservedCost(
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
+            eq(12L),
+            eq(202603),
+            eq(new BigDecimal("0.33"))
+        )).thenReturn(1);
+
+        // when
+        int expiredCount = budgetReservationService.expireStaleReservations();
+
+        // then
+        assertThat(expiredCount).isEqualTo(1);
+        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.EXPIRED);
+        assertThat(reservation.getReleaseReason()).isEqualTo("RESERVATION_EXPIRED");
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,10 +38,10 @@ class BudgetReservationServiceTest {
     private BudgetReservationRepository budgetReservationRepository;
 
     @Mock
-    private BudgetUsageRowInitializer budgetUsageRowInitializer;
+    private BudgetReservationMetrics budgetReservationMetrics;
 
     @Mock
-    private BudgetReservationMetrics budgetReservationMetrics;
+    private BudgetReservationCommandService budgetReservationCommandService;
 
     @InjectMocks
     private BudgetReservationService budgetReservationService;
@@ -55,15 +56,33 @@ class BudgetReservationServiceTest {
         BigDecimal monthLimitUsd = new BigDecimal("10.00");
         BigDecimal reserveAmount = new BigDecimal("0.80");
 
-        when(budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
-            eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
+        BudgetReservation savedReservation = BudgetReservation.reserve(
+            requestLogId,
+            traceId,
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            reserveAmount,
+            1200,
+            512,
+            LocalDateTime.now().plusSeconds(90)
+        );
+        when(budgetReservationCommandService.reserve(
+            eq(requestLogId),
+            eq(traceId),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
             eq(10L),
             eq(202603),
+            eq(monthLimitUsd),
             eq(reserveAmount),
-            eq(monthLimitUsd)
-        )).thenReturn(1);
-        when(budgetReservationRepository.save(any(BudgetReservation.class)))
-            .thenAnswer(invocation -> invocation.getArgument(0));
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(1200),
+            eq(512),
+            any(LocalDateTime.class)
+        )).thenReturn(Optional.of(savedReservation));
 
         // when
         Optional<BudgetReservation> result = budgetReservationService.reserve(
@@ -86,21 +105,26 @@ class BudgetReservationServiceTest {
         assertThat(result.get().getTraceId()).isEqualTo(traceId);
         assertThat(result.get().getStatus()).isEqualTo(BudgetReservationStatus.RESERVED);
         assertThat(result.get().getReservedCostUsd()).isEqualByComparingTo(reserveAmount);
-        verify(budgetUsageRowInitializer).ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 10L, 202603);
-        verify(budgetReservationMetrics).incrementReserve(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 
     @Test
     @DisplayName("예산 한도 초과이면 reservation을 생성하지 않는다")
     void 예산_한도_초과이면_reservation을_생성하지_않는다() {
         // given
-        when(budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
-            eq(BudgetScopeType.WORKSPACE.name()),
+        when(budgetReservationCommandService.reserve(
+            any(),
+            eq("trace-2"),
+            eq(BudgetScopeType.WORKSPACE),
             eq(7L),
             eq(202603),
+            eq(new BigDecimal("5.00")),
             eq(new BigDecimal("1.50")),
-            eq(new BigDecimal("5.00"))
-        )).thenReturn(0);
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(1000),
+            eq(256),
+            any(LocalDateTime.class)
+        )).thenReturn(Optional.empty());
 
         // when
         Optional<BudgetReservation> result = budgetReservationService.reserve(
@@ -120,7 +144,104 @@ class BudgetReservationServiceTest {
 
         // then
         assertThat(result).isEmpty();
-        verify(budgetReservationMetrics).incrementReserveFailed(BudgetScopeType.WORKSPACE, "LIMIT_EXCEEDED");
+    }
+
+    @Test
+    @DisplayName("같은 traceId reservation이 이미 존재하면 기존 reservation을 재사용한다")
+    void 같은_traceId_reservation이_이미_존재하면_기존_reservation을_재사용한다() {
+        // given
+        BudgetReservation existingReservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-duplicate",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.80"),
+            1200,
+            512,
+            LocalDateTime.now().plusSeconds(90)
+        );
+        when(budgetReservationCommandService.reserve(
+            any(),
+            eq("trace-duplicate"),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(202603),
+            eq(new BigDecimal("10.00")),
+            eq(new BigDecimal("0.80")),
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(1200),
+            eq(512),
+            any(LocalDateTime.class)
+        )).thenThrow(new DataIntegrityViolationException("duplicate"));
+        when(budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(
+            "trace-duplicate",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L
+        )).thenReturn(Optional.of(existingReservation));
+
+        // when
+        Optional<BudgetReservation> result = budgetReservationService.reserve(
+            UUID.randomUUID(),
+            "trace-duplicate",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L,
+            YearMonth.of(2026, 3),
+            new BigDecimal("10.00"),
+            new BigDecimal("0.80"),
+            "openai",
+            "gpt-4.1-mini",
+            1200,
+            512,
+            Duration.ofSeconds(90)
+        );
+
+        // then
+        assertThat(result).contains(existingReservation);
+    }
+
+    @Test
+    @DisplayName("같은 traceId reservation을 찾지 못하면 예외를 다시 던진다")
+    void 같은_traceId_reservation을_찾지_못하면_예외를_다시_던진다() {
+        // given
+        when(budgetReservationCommandService.reserve(
+            any(),
+            eq("trace-missing"),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(202603),
+            eq(new BigDecimal("10.00")),
+            eq(new BigDecimal("0.80")),
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(1200),
+            eq(512),
+            any(LocalDateTime.class)
+        )).thenThrow(new DataIntegrityViolationException("duplicate"));
+        when(budgetReservationRepository.findByTraceIdAndScopeTypeAndScopeId(
+            "trace-missing",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L
+        )).thenReturn(Optional.empty());
+
+        // when // then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> budgetReservationService.reserve(
+            UUID.randomUUID(),
+            "trace-missing",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L,
+            YearMonth.of(2026, 3),
+            new BigDecimal("10.00"),
+            new BigDecimal("0.80"),
+            "openai",
+            "gpt-4.1-mini",
+            1200,
+            512,
+            Duration.ofSeconds(90)
+        )).isInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -125,7 +127,7 @@ class BudgetReservationServiceTest {
     @DisplayName("reservation이 RESERVED 상태이면 settle한다")
     void reservation이_RESERVED_상태이면_settle한다() {
         // given
-        BudgetReservation reservation = BudgetReservation.reserve(
+        when(budgetReservationRepository.findById(1L)).thenReturn(Optional.of(BudgetReservation.reserve(
             UUID.randomUUID(),
             "trace-3",
             BudgetScopeType.PROVIDER_CREDENTIAL,
@@ -137,9 +139,9 @@ class BudgetReservationServiceTest {
             900,
             256,
             java.time.LocalDateTime.now().plusMinutes(1)
-        );
+        )));
 
-        when(budgetReservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(budgetReservationRepository.markSettledIfReserved(1L, new BigDecimal("0.42"))).thenReturn(1);
         when(budgetMonthlyUsageRepository.settleReservation(
             eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
             eq(11L),
@@ -154,8 +156,7 @@ class BudgetReservationServiceTest {
         budgetReservationService.settle(1L, new BigDecimal("0.42"), 777L);
 
         // then
-        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
-        assertThat(reservation.getSettledCostUsd()).isEqualByComparingTo("0.42");
+        verify(budgetReservationRepository).markSettledIfReserved(1L, new BigDecimal("0.42"));
         verify(budgetReservationMetrics).incrementSettle(BudgetScopeType.PROVIDER_CREDENTIAL);
     }
 
@@ -176,8 +177,11 @@ class BudgetReservationServiceTest {
             256,
             java.time.LocalDateTime.now().plusMinutes(1)
         );
+        ReflectionTestUtils.setField(reservation, "id", 2L);
 
         when(budgetReservationRepository.findById(2L)).thenReturn(Optional.of(reservation));
+
+        when(budgetReservationRepository.markReleasedIfReserved(2L, "PRIMARY_ROUTE_FAILED")).thenReturn(1);
         when(budgetMonthlyUsageRepository.releaseReservedCost(
             eq(BudgetScopeType.WORKSPACE.name()),
             eq(8L),
@@ -189,8 +193,7 @@ class BudgetReservationServiceTest {
         budgetReservationService.release(2L, "PRIMARY_ROUTE_FAILED");
 
         // then
-        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
-        assertThat(reservation.getReleaseReason()).isEqualTo("PRIMARY_ROUTE_FAILED");
+        verify(budgetReservationRepository).markReleasedIfReserved(2L, "PRIMARY_ROUTE_FAILED");
         verify(budgetReservationMetrics).incrementRelease(BudgetScopeType.WORKSPACE, "PRIMARY_ROUTE_FAILED");
     }
 
@@ -211,10 +214,12 @@ class BudgetReservationServiceTest {
             256,
             LocalDateTime.now().minusMinutes(1)
         );
+        ReflectionTestUtils.setField(reservation, "id", 1L);
         when(budgetReservationRepository.findTop100ByStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
             eq(BudgetReservationStatus.RESERVED),
             any(LocalDateTime.class)
         )).thenReturn(List.of(reservation));
+        when(budgetReservationRepository.markExpiredIfReserved(1L, "RESERVATION_EXPIRED")).thenReturn(1);
         when(budgetMonthlyUsageRepository.releaseReservedCost(
             eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
             eq(12L),
@@ -227,8 +232,52 @@ class BudgetReservationServiceTest {
 
         // then
         assertThat(expiredCount).isEqualTo(1);
-        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.EXPIRED);
-        assertThat(reservation.getReleaseReason()).isEqualTo("RESERVATION_EXPIRED");
+        verify(budgetReservationRepository).markExpiredIfReserved(1L, "RESERVATION_EXPIRED");
         verify(budgetReservationMetrics).incrementExpired(BudgetScopeType.PROVIDER_CREDENTIAL);
+    }
+
+    @Test
+    @DisplayName("정산 도중 다른 경로가 먼저 종료한 reservation이면 조용히 종료한다")
+    void 정산_도중_다른_경로가_먼저_종료한_reservation이면_조용히_종료한다() {
+        // given
+        BudgetReservation reservedReservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-race",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            13L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.25"),
+            100,
+            64,
+            LocalDateTime.now().plusMinutes(1)
+        );
+        BudgetReservation releasedReservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-race",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            13L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.25"),
+            100,
+            64,
+            LocalDateTime.now().plusMinutes(1)
+        );
+        releasedReservation.markReleased("PRIMARY_ROUTE_FAILED");
+
+        when(budgetReservationRepository.findById(3L))
+            .thenReturn(Optional.of(reservedReservation))
+            .thenReturn(Optional.of(releasedReservation));
+        when(budgetReservationRepository.markSettledIfReserved(3L, new BigDecimal("0.10"))).thenReturn(0);
+
+        // when
+        budgetReservationService.settle(3L, new BigDecimal("0.10"), 77L);
+
+        // then
+        verify(budgetMonthlyUsageRepository, never()).settleReservation(any(), any(), any(), any(), any(), any(), any());
+        verify(budgetReservationMetrics, never()).incrementSettle(any());
     }
 }

--- a/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/budget/service/BudgetReservationServiceTest.java
@@ -1,0 +1,184 @@
+package com.llm_ops.demo.budget.service;
+
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.YearMonth;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetReservationServiceTest {
+
+    @Mock
+    private BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+
+    @Mock
+    private BudgetReservationRepository budgetReservationRepository;
+
+    @InjectMocks
+    private BudgetReservationService budgetReservationService;
+
+    @Test
+    @DisplayName("예산 한도 내이면 reservation을 생성한다")
+    void 예산_한도_내이면_reservation을_생성한다() {
+        // given
+        UUID requestLogId = UUID.randomUUID();
+        String traceId = "trace-1";
+        YearMonth yearMonth = YearMonth.of(2026, 3);
+        BigDecimal monthLimitUsd = new BigDecimal("10.00");
+        BigDecimal reserveAmount = new BigDecimal("0.80");
+
+        when(budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
+            eq(10L),
+            eq(202603),
+            eq(reserveAmount),
+            eq(monthLimitUsd)
+        )).thenReturn(1);
+        when(budgetReservationRepository.save(any(BudgetReservation.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Optional<BudgetReservation> result = budgetReservationService.reserve(
+            requestLogId,
+            traceId,
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            10L,
+            yearMonth,
+            monthLimitUsd,
+            reserveAmount,
+            "openai",
+            "gpt-4.1-mini",
+            1200,
+            512,
+            Duration.ofSeconds(90)
+        );
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getTraceId()).isEqualTo(traceId);
+        assertThat(result.get().getStatus()).isEqualTo(BudgetReservationStatus.RESERVED);
+        assertThat(result.get().getReservedCostUsd()).isEqualByComparingTo(reserveAmount);
+        verify(budgetMonthlyUsageRepository).ensureUsageRow(BudgetScopeType.PROVIDER_CREDENTIAL.name(), 10L, 202603);
+    }
+
+    @Test
+    @DisplayName("예산 한도 초과이면 reservation을 생성하지 않는다")
+    void 예산_한도_초과이면_reservation을_생성하지_않는다() {
+        // given
+        when(budgetMonthlyUsageRepository.reserveCostIfWithinLimit(
+            eq(BudgetScopeType.WORKSPACE.name()),
+            eq(7L),
+            eq(202603),
+            eq(new BigDecimal("1.50")),
+            eq(new BigDecimal("5.00"))
+        )).thenReturn(0);
+
+        // when
+        Optional<BudgetReservation> result = budgetReservationService.reserve(
+            UUID.randomUUID(),
+            "trace-2",
+            BudgetScopeType.WORKSPACE,
+            7L,
+            YearMonth.of(2026, 3),
+            new BigDecimal("5.00"),
+            new BigDecimal("1.50"),
+            "openai",
+            "gpt-4.1-mini",
+            1000,
+            256,
+            Duration.ofSeconds(60)
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reservation이 RESERVED 상태이면 settle한다")
+    void reservation이_RESERVED_상태이면_settle한다() {
+        // given
+        BudgetReservation reservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-3",
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            11L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.70"),
+            900,
+            256,
+            java.time.LocalDateTime.now().plusMinutes(1)
+        );
+
+        when(budgetReservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(budgetMonthlyUsageRepository.settleReservation(
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL.name()),
+            eq(11L),
+            eq(202603),
+            eq(new BigDecimal("0.70")),
+            eq(new BigDecimal("0.42")),
+            eq(777L),
+            eq(1L)
+        )).thenReturn(1);
+
+        // when
+        budgetReservationService.settle(1L, new BigDecimal("0.42"), 777L);
+
+        // then
+        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
+        assertThat(reservation.getSettledCostUsd()).isEqualByComparingTo("0.42");
+    }
+
+    @Test
+    @DisplayName("reservation이 RESERVED 상태이면 release한다")
+    void reservation이_RESERVED_상태이면_release한다() {
+        // given
+        BudgetReservation reservation = BudgetReservation.reserve(
+            UUID.randomUUID(),
+            "trace-4",
+            BudgetScopeType.WORKSPACE,
+            8L,
+            202603,
+            "openai",
+            "gpt-4.1-mini",
+            new BigDecimal("0.55"),
+            800,
+            256,
+            java.time.LocalDateTime.now().plusMinutes(1)
+        );
+
+        when(budgetReservationRepository.findById(2L)).thenReturn(Optional.of(reservation));
+        when(budgetMonthlyUsageRepository.releaseReservedCost(
+            eq(BudgetScopeType.WORKSPACE.name()),
+            eq(8L),
+            eq(202603),
+            eq(new BigDecimal("0.55"))
+        )).thenReturn(1);
+
+        // when
+        budgetReservationService.release(2L, "PRIMARY_ROUTE_FAILED");
+
+        // then
+        assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.RELEASED);
+        assertThat(reservation.getReleaseReason()).isEqualTo("PRIMARY_ROUTE_FAILED");
+    }
+}

--- a/src/test/java/com/llm_ops/demo/config/TestChatModelConfig.java
+++ b/src/test/java/com/llm_ops/demo/config/TestChatModelConfig.java
@@ -23,6 +23,7 @@ public class TestChatModelConfig {
     ChatModel openAiChatModel(TestChatModelState testChatModelState) {
         return prompt -> {
             testChatModelState.record(prompt);
+            testChatModelState.awaitIfBlocked();
             return new ChatResponse(
                 List.of(new Generation(new AssistantMessage(prompt.getContents())))
             );

--- a/src/test/java/com/llm_ops/demo/config/TestChatModelState.java
+++ b/src/test/java/com/llm_ops/demo/config/TestChatModelState.java
@@ -2,17 +2,66 @@ package com.llm_ops.demo.config;
 
 import org.springframework.ai.chat.prompt.Prompt;
 
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestChatModelState {
 
     private final AtomicReference<Prompt> lastPrompt = new AtomicReference<>();
+    private final AtomicInteger callCount = new AtomicInteger();
+    private final AtomicReference<CountDownLatch> providerCallStartedLatch = new AtomicReference<>(new CountDownLatch(0));
+    private final AtomicReference<CountDownLatch> releaseResponsesLatch = new AtomicReference<>();
 
     public void record(Prompt prompt) {
         lastPrompt.set(prompt);
+        callCount.incrementAndGet();
+        providerCallStartedLatch.get().countDown();
     }
 
     public Prompt getLastPrompt() {
         return lastPrompt.get();
+    }
+
+    public int getCallCount() {
+        return callCount.get();
+    }
+
+    public void prepareBlockingResponse() {
+        providerCallStartedLatch.set(new CountDownLatch(1));
+        releaseResponsesLatch.set(new CountDownLatch(1));
+    }
+
+    public boolean awaitProviderCallStarted(Duration timeout) throws InterruptedException {
+        return providerCallStartedLatch.get().await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public void awaitIfBlocked() {
+        CountDownLatch latch = releaseResponsesLatch.get();
+        if (latch == null) {
+            return;
+        }
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("테스트용 ChatModel 대기 중 인터럽트가 발생했습니다.", e);
+        }
+    }
+
+    public void releaseBlockedResponses() {
+        CountDownLatch latch = releaseResponsesLatch.getAndSet(null);
+        if (latch != null) {
+            latch.countDown();
+        }
+    }
+
+    public void reset() {
+        lastPrompt.set(null);
+        callCount.set(0);
+        providerCallStartedLatch.set(new CountDownLatch(0));
+        releaseBlockedResponses();
     }
 }

--- a/src/test/java/com/llm_ops/demo/e2e/GatewayBudgetConcurrencyE2ETest.java
+++ b/src/test/java/com/llm_ops/demo/e2e/GatewayBudgetConcurrencyE2ETest.java
@@ -1,0 +1,314 @@
+package com.llm_ops.demo.e2e;
+
+import com.llm_ops.demo.auth.domain.User;
+import com.llm_ops.demo.auth.repository.UserRepository;
+import com.llm_ops.demo.budget.domain.BudgetReservation;
+import com.llm_ops.demo.budget.domain.BudgetReservationStatus;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
+import com.llm_ops.demo.budget.domain.BudgetSoftAction;
+import com.llm_ops.demo.budget.dto.BudgetPolicyUpdateRequest;
+import com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepository;
+import com.llm_ops.demo.budget.repository.BudgetPolicyRepository;
+import com.llm_ops.demo.budget.repository.BudgetReservationRepository;
+import com.llm_ops.demo.budget.service.BudgetPolicyService;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimate;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimator;
+import com.llm_ops.demo.budget.service.BudgetUsageService;
+import com.llm_ops.demo.config.TestChatModelState;
+import com.llm_ops.demo.config.TestSecurityConfig;
+import com.llm_ops.demo.gateway.log.repository.RequestLogRepository;
+import com.llm_ops.demo.keys.domain.ProviderType;
+import com.llm_ops.demo.keys.dto.OrganizationApiKeyCreateRequest;
+import com.llm_ops.demo.keys.dto.OrganizationApiKeyCreateResponse;
+import com.llm_ops.demo.keys.dto.ProviderCredentialCreateRequest;
+import com.llm_ops.demo.keys.repository.OrganizationApiKeyRepository;
+import com.llm_ops.demo.keys.repository.ProviderCredentialRepository;
+import com.llm_ops.demo.keys.service.OrganizationApiKeyCreateService;
+import com.llm_ops.demo.keys.service.ProviderCredentialService;
+import com.llm_ops.demo.organization.domain.Organization;
+import com.llm_ops.demo.organization.repository.OrganizationRepository;
+import com.llm_ops.demo.prompt.domain.Prompt;
+import com.llm_ops.demo.prompt.domain.PromptRelease;
+import com.llm_ops.demo.prompt.domain.PromptVersion;
+import com.llm_ops.demo.prompt.repository.PromptReleaseRepository;
+import com.llm_ops.demo.prompt.repository.PromptRepository;
+import com.llm_ops.demo.prompt.repository.PromptVersionRepository;
+import com.llm_ops.demo.workspace.domain.Workspace;
+import com.llm_ops.demo.workspace.repository.WorkspaceRepository;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"test", "mock-auth"})
+@TestPropertySource(properties = "PROVIDER_KEY_ENC_KEY=test-secret")
+@Import(TestSecurityConfig.class)
+@DisplayName("E2E 통합 테스트 - Gateway Budget Concurrency")
+class GatewayBudgetConcurrencyE2ETest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private OrganizationApiKeyCreateService organizationApiKeyCreateService;
+
+    @Autowired
+    private OrganizationApiKeyRepository organizationApiKeyRepository;
+
+    @Autowired
+    private ProviderCredentialService providerCredentialService;
+
+    @Autowired
+    private ProviderCredentialRepository providerCredentialRepository;
+
+    @Autowired
+    private BudgetPolicyService budgetPolicyService;
+
+    @Autowired
+    private BudgetPolicyRepository budgetPolicyRepository;
+
+    @Autowired
+    private BudgetMonthlyUsageRepository budgetMonthlyUsageRepository;
+
+    @Autowired
+    private BudgetReservationRepository budgetReservationRepository;
+
+    @Autowired
+    private BudgetReservationEstimator budgetReservationEstimator;
+
+    @Autowired
+    private RequestLogRepository requestLogRepository;
+
+    @Autowired
+    private TestChatModelState testChatModelState;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    private PromptRepository promptRepository;
+
+    @Autowired
+    private PromptVersionRepository promptVersionRepository;
+
+    @Autowired
+    private PromptReleaseRepository promptReleaseRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private MockMvc mockMvc;
+    private OrganizationApiKeyCreateResponse apiKeyResponse;
+    private Long organizationId;
+    private Long workspaceId;
+    private Long providerCredentialId;
+    private String promptKey;
+    private Workspace workspace;
+    private User creatorUser;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+        clearData();
+        testChatModelState.reset();
+
+        creatorUser = userRepository.save(User.create("test@example.com", "password", "tester"));
+        Organization organization = organizationRepository.save(Organization.create("테스트 조직", creatorUser));
+        workspace = workspaceRepository.save(Workspace.create(organization, "default", "기본"));
+        organizationId = organization.getId();
+        workspaceId = workspace.getId();
+        promptKey = createReleasedPrompt("budget-bot", "hello {{name}}");
+
+        apiKeyResponse = organizationApiKeyCreateService.create(
+            organizationId,
+            new OrganizationApiKeyCreateRequest("prod")
+        );
+
+        providerCredentialService.register(
+            organizationId,
+            new ProviderCredentialCreateRequest("openai", "provider-key")
+        );
+        providerCredentialId = activateCredential(organizationId, ProviderType.OPENAI);
+        configureBudgetToAllowSingleInFlightRequest();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testChatModelState.releaseBlockedResponses();
+        testChatModelState.reset();
+        clearData();
+    }
+
+    @Test
+    @DisplayName("in-flight reservation이 있으면 겹치는 두 번째 HTTP 요청은 429로 차단된다")
+    void in_flight_reservation이_있으면_겹치는_두_번째_HTTP_요청은_429로_차단된다() throws Exception {
+        // given
+        testChatModelState.prepareBlockingResponse();
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        String requestBody = requestBody("lumina");
+        YearMonth budgetMonth = YearMonth.now(ZoneOffset.UTC);
+
+        try {
+            Future<MvcResult> firstRequest = executorService.submit(() -> performChat(requestBody));
+            assertThat(testChatModelState.awaitProviderCallStarted(Duration.ofSeconds(5))).isTrue();
+
+            // when
+            Future<MvcResult> secondRequest = executorService.submit(() -> performChat(requestBody));
+            MvcResult secondResult = secondRequest.get(5, TimeUnit.SECONDS);
+            testChatModelState.releaseBlockedResponses();
+            MvcResult firstResult = firstRequest.get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(firstResult.getResponse().getStatus()).isEqualTo(200);
+            assertThat(firstResult.getResponse().getContentAsString()).contains("\"answer\":\"hello lumina\"");
+
+            assertThat(secondResult.getResponse().getStatus()).isEqualTo(429);
+            assertThat(secondResult.getResponse().getContentAsString()).contains("\"code\":\"GW-REQ-QUOTA_EXCEEDED\"");
+
+            assertThat(testChatModelState.getCallCount()).isEqualTo(1);
+            assertThat(budgetReservationRepository.findAll()).hasSize(1);
+
+            BudgetReservation reservation = budgetReservationRepository.findAll().get(0);
+            assertThat(reservation.getStatus()).isEqualTo(BudgetReservationStatus.SETTLED);
+
+            var usage = budgetMonthlyUsageRepository.findByScopeTypeAndScopeIdAndYearMonth(
+                BudgetScopeType.PROVIDER_CREDENTIAL,
+                providerCredentialId,
+                BudgetUsageService.toYearMonthInt(budgetMonth)
+            );
+            assertThat(usage).isPresent();
+            assertThat(usage.orElseThrow().getReservedCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(usage.orElseThrow().getRequestCount()).isEqualTo(1L);
+        } finally {
+            testChatModelState.releaseBlockedResponses();
+            executorService.shutdownNow();
+        }
+    }
+
+    private MvcResult performChat(String requestBody) throws Exception {
+        return mockMvc.perform(post("/v1/chat/completions")
+                .header("X-API-Key", apiKeyResponse.apiKey())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andReturn();
+    }
+
+    private String requestBody(String name) {
+        return String.format("""
+            {
+              "workspaceId": %d,
+              "promptKey": "%s",
+              "variables": {
+                "name": "%s"
+              }
+            }
+            """, workspaceId, promptKey, name);
+    }
+
+    private void configureBudgetToAllowSingleInFlightRequest() {
+        BudgetReservationEstimate estimate = budgetReservationEstimator.estimate(
+            "gpt-4o-mini",
+            null,
+            "hello lumina",
+            null
+        );
+        assertThat(estimate.reservable()).isTrue();
+
+        budgetPolicyService.upsertPolicy(
+            BudgetScopeType.PROVIDER_CREDENTIAL,
+            providerCredentialId,
+            new BudgetPolicyUpdateRequest(
+                estimate.reserveAmountUsd(),
+                null,
+                BudgetSoftAction.DEGRADE,
+                Map.of(),
+                512,
+                false,
+                true
+            )
+        );
+    }
+
+    private Long activateCredential(Long orgId, ProviderType providerType) {
+        var credential = providerCredentialRepository
+            .findByOrganizationIdAndProvider(orgId, providerType)
+            .orElseThrow();
+        credential.markActive();
+        providerCredentialRepository.save(credential);
+        return credential.getId();
+    }
+
+    private String createReleasedPrompt(String key, String userTemplate) {
+        return transactionTemplate.execute(status -> {
+            Prompt prompt = promptRepository.save(Prompt.create(workspace, key, "test prompt"));
+            PromptVersion version = promptVersionRepository.save(
+                PromptVersion.create(
+                    prompt,
+                    1,
+                    "v1",
+                    ProviderType.OPENAI,
+                    "gpt-4o-mini",
+                    null,
+                    null,
+                    null,
+                    userTemplate,
+                    false,
+                    null,
+                    null,
+                    creatorUser
+                )
+            );
+            PromptRelease release = PromptRelease.create(prompt, version);
+            promptReleaseRepository.save(release);
+            return prompt.getPromptKey();
+        });
+    }
+
+    private void clearData() {
+        budgetReservationRepository.deleteAll();
+        budgetMonthlyUsageRepository.deleteAll();
+        budgetPolicyRepository.deleteAll();
+        requestLogRepository.deleteAll();
+        organizationApiKeyRepository.deleteAll();
+        providerCredentialRepository.deleteAll();
+        promptReleaseRepository.deleteAll();
+        promptVersionRepository.deleteAll();
+        promptRepository.deleteAll();
+        workspaceRepository.deleteAll();
+        organizationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/llm_ops/demo/gateway/service/GatewayChatServiceUnitTest.java
+++ b/src/test/java/com/llm_ops/demo/gateway/service/GatewayChatServiceUnitTest.java
@@ -1,6 +1,8 @@
 package com.llm_ops.demo.gateway.service;
 
 import com.google.genai.errors.ApiException;
+import com.llm_ops.demo.budget.domain.BudgetPolicy;
+import com.llm_ops.demo.budget.domain.BudgetScopeType;
 import com.llm_ops.demo.gateway.config.GatewayReliabilityProperties;
 import com.llm_ops.demo.gateway.dto.GatewayChatRequest;
 import com.llm_ops.demo.gateway.dto.GatewayChatResponse;
@@ -9,6 +11,10 @@ import com.llm_ops.demo.gateway.log.domain.RequestLogAttemptRoute;
 import com.llm_ops.demo.gateway.log.service.RequestLogWriter;
 import com.llm_ops.demo.budget.service.BudgetDecision;
 import com.llm_ops.demo.budget.service.BudgetGuardrailService;
+import com.llm_ops.demo.budget.service.BudgetPolicyService;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimate;
+import com.llm_ops.demo.budget.service.BudgetReservationEstimator;
+import com.llm_ops.demo.budget.service.BudgetReservationService;
 import com.llm_ops.demo.budget.service.BudgetUsageService;
 import com.llm_ops.demo.global.error.GatewayException;
 import com.llm_ops.demo.keys.domain.ProviderType;
@@ -107,6 +113,15 @@ class GatewayChatServiceUnitTest {
     private BudgetGuardrailService budgetGuardrailService;
 
     @Mock
+    private BudgetPolicyService budgetPolicyService;
+
+    @Mock
+    private BudgetReservationEstimator budgetReservationEstimator;
+
+    @Mock
+    private BudgetReservationService budgetReservationService;
+
+    @Mock
     private BudgetUsageService budgetUsageService;
 
     @Mock
@@ -151,6 +166,8 @@ class GatewayChatServiceUnitTest {
                                 invocation.getArgument(0),
                                 CircuitBreaker::ofDefaults
                         ));
+        lenient().when(budgetPolicyService.findPolicy(eq(BudgetScopeType.PROVIDER_CREDENTIAL), any()))
+                .thenReturn(Optional.empty());
     }
 
     @Test
@@ -950,6 +967,240 @@ class GatewayChatServiceUnitTest {
             method.setAccessible(true);
             return (boolean) method.invoke(gatewayChatService, exception);
         }
+    }
+
+    @Test
+    @DisplayName("Provider 예산 정책이 있으면 reserve 후 settle하고 provider usage는 중복 기록하지 않는다")
+    void provider_예산_정책이_있으면_reserve_후_settle하고_provider_usage는_중복_기록하지_않는다() {
+        // given
+        String apiKey = "lum_test";
+        Long organizationId = 1L;
+        Long workspaceId = 1L;
+        UUID requestId = UUID.randomUUID();
+
+        OrganizationApiKeyAuthService.AuthResult authResult =
+            new OrganizationApiKeyAuthService.AuthResult(organizationId, 99L, "lum_test");
+        when(organizationApiKeyAuthService.resolveAuthResult(apiKey)).thenReturn(authResult);
+        when(requestLogWriter.start(any())).thenReturn(requestId);
+
+        Workspace workspace = org.mockito.Mockito.mock(Workspace.class);
+        when(workspace.getId()).thenReturn(workspaceId);
+        when(workspaceRepository.findByIdAndOrganizationIdAndStatus(workspaceId, organizationId, WorkspaceStatus.ACTIVE))
+            .thenReturn(Optional.of(workspace));
+
+        com.llm_ops.demo.prompt.domain.Prompt promptEntity = org.mockito.Mockito.mock(com.llm_ops.demo.prompt.domain.Prompt.class);
+        when(promptEntity.getId()).thenReturn(100L);
+        when(promptRepository.findByWorkspaceAndPromptKeyAndStatus(eq(workspace), eq("hello"), eq(PromptStatus.ACTIVE)))
+            .thenReturn(Optional.of(promptEntity));
+
+        PromptVersion activeVersion = org.mockito.Mockito.mock(PromptVersion.class);
+        when(activeVersion.getUserTemplate()).thenReturn("hello");
+        when(activeVersion.getSystemPrompt()).thenReturn(null);
+        when(activeVersion.getProvider()).thenReturn(ProviderType.OPENAI);
+        when(activeVersion.getModel()).thenReturn("gpt-4.1-mini");
+
+        PromptRelease release = org.mockito.Mockito.mock(PromptRelease.class);
+        when(release.getActiveVersion()).thenReturn(activeVersion);
+        when(promptReleaseRepository.findWithActiveVersionByPromptId(100L)).thenReturn(Optional.of(release));
+
+        when(providerCredentialService.resolveApiKey(eq(organizationId), eq(ProviderType.OPENAI)))
+            .thenReturn(new ProviderCredentialService.ResolvedProviderApiKey(10L, ProviderType.OPENAI, "provider-key"));
+        when(budgetUsageService.currentUtcYearMonth()).thenReturn(YearMonth.of(2026, 2));
+        when(budgetGuardrailService.evaluateWorkspaceDegrade(eq(workspaceId), anyString())).thenReturn(BudgetDecision.allow());
+        when(budgetGuardrailService.evaluateProviderCredential(eq(10L))).thenReturn(BudgetDecision.allow());
+
+        BudgetPolicy policy = BudgetPolicy.createDefault(BudgetScopeType.PROVIDER_CREDENTIAL, 10L);
+        policy.update(new java.math.BigDecimal("10.00"), null, null, null, null, null, true);
+        when(budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, 10L)).thenReturn(Optional.of(policy));
+        when(budgetReservationEstimator.estimate(eq("gpt-4.1-mini"), any(), any(), any()))
+            .thenReturn(BudgetReservationEstimate.reservable(
+                "gpt-4.1-mini",
+                120,
+                512,
+                new java.math.BigDecimal("0.50")
+            ));
+
+        com.llm_ops.demo.budget.domain.BudgetReservation reservation = org.mockito.Mockito.mock(com.llm_ops.demo.budget.domain.BudgetReservation.class);
+        when(reservation.getId()).thenReturn(33L);
+        when(budgetReservationService.reserve(
+            eq(requestId),
+            anyString(),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(YearMonth.of(2026, 2)),
+            eq(new java.math.BigDecimal("10.00")),
+            eq(new java.math.BigDecimal("0.50")),
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(120),
+            eq(512),
+            any()
+        )).thenReturn(Optional.of(reservation));
+
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+            .withModel("gpt-4.1-mini")
+            .withUsage(new DefaultUsage(100L, 50L, 150L))
+            .build();
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))), metadata);
+        when(llmCallService.callProvider(any(), anyString(), any(), anyString(), any())).thenReturn(chatResponse);
+
+        GatewayChatRequest request = new GatewayChatRequest(workspaceId, "hello", Map.of(), false);
+
+        // when
+        gatewayChatService.chat(apiKey, request);
+
+        // then
+        verify(budgetReservationService).settle(
+            33L,
+            com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("gpt-4.1-mini", 100, 50),
+            150L
+        );
+        verify(budgetUsageService).recordUsage(
+            eq(BudgetScopeType.WORKSPACE),
+            eq(workspaceId),
+            eq(YearMonth.of(2026, 2)),
+            eq(com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("gpt-4.1-mini", 100, 50)),
+            eq(150L)
+        );
+        verify(budgetUsageService, never()).recordUsage(
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(YearMonth.of(2026, 2)),
+            any(),
+            any()
+        );
+    }
+
+    @Test
+    @DisplayName("Primary 실패 후 secondary failover면 primary reservation을 release하고 secondary reservation을 settle한다")
+    void primary_실패_후_secondary_failover면_primary_reservation을_release하고_secondary_reservation을_settle한다() {
+        // given
+        String apiKey = "lum_test";
+        Long organizationId = 1L;
+        Long workspaceId = 1L;
+        UUID requestId = UUID.randomUUID();
+
+        OrganizationApiKeyAuthService.AuthResult authResult =
+            new OrganizationApiKeyAuthService.AuthResult(organizationId, 99L, "lum_test");
+        when(organizationApiKeyAuthService.resolveAuthResult(apiKey)).thenReturn(authResult);
+        when(requestLogWriter.start(any())).thenReturn(requestId);
+
+        Workspace workspace = org.mockito.Mockito.mock(Workspace.class);
+        when(workspace.getId()).thenReturn(workspaceId);
+        when(workspaceRepository.findByIdAndOrganizationIdAndStatus(workspaceId, organizationId, WorkspaceStatus.ACTIVE))
+            .thenReturn(Optional.of(workspace));
+
+        com.llm_ops.demo.prompt.domain.Prompt promptEntity = org.mockito.Mockito.mock(com.llm_ops.demo.prompt.domain.Prompt.class);
+        when(promptEntity.getId()).thenReturn(100L);
+        when(promptRepository.findByWorkspaceAndPromptKeyAndStatus(eq(workspace), eq("hello"), eq(PromptStatus.ACTIVE)))
+            .thenReturn(Optional.of(promptEntity));
+
+        PromptVersion activeVersion = org.mockito.Mockito.mock(PromptVersion.class);
+        when(activeVersion.getUserTemplate()).thenReturn("hello");
+        when(activeVersion.getSystemPrompt()).thenReturn(null);
+        when(activeVersion.getProvider()).thenReturn(ProviderType.OPENAI);
+        when(activeVersion.getModel()).thenReturn("gpt-4.1-mini");
+        when(activeVersion.getSecondaryProvider()).thenReturn(ProviderType.ANTHROPIC);
+        when(activeVersion.getSecondaryModel()).thenReturn("claude-3-5-haiku");
+
+        PromptRelease release = org.mockito.Mockito.mock(PromptRelease.class);
+        when(release.getActiveVersion()).thenReturn(activeVersion);
+        when(promptReleaseRepository.findWithActiveVersionByPromptId(100L)).thenReturn(Optional.of(release));
+
+        when(providerCredentialService.resolveApiKey(eq(organizationId), eq(ProviderType.OPENAI)))
+            .thenReturn(new ProviderCredentialService.ResolvedProviderApiKey(10L, ProviderType.OPENAI, "primary-key"));
+        when(providerCredentialService.resolveApiKey(eq(organizationId), eq(ProviderType.ANTHROPIC)))
+            .thenReturn(new ProviderCredentialService.ResolvedProviderApiKey(11L, ProviderType.ANTHROPIC, "secondary-key"));
+        when(budgetUsageService.currentUtcYearMonth()).thenReturn(YearMonth.of(2026, 2));
+        when(budgetGuardrailService.evaluateWorkspaceDegrade(eq(workspaceId), anyString())).thenReturn(BudgetDecision.allow());
+        when(budgetGuardrailService.evaluateProviderCredential(eq(10L))).thenReturn(BudgetDecision.allow());
+        when(budgetGuardrailService.evaluateProviderCredential(eq(11L))).thenReturn(BudgetDecision.allow());
+
+        BudgetPolicy primaryPolicy = BudgetPolicy.createDefault(BudgetScopeType.PROVIDER_CREDENTIAL, 10L);
+        primaryPolicy.update(new java.math.BigDecimal("10.00"), null, null, null, null, null, true);
+        BudgetPolicy secondaryPolicy = BudgetPolicy.createDefault(BudgetScopeType.PROVIDER_CREDENTIAL, 11L);
+        secondaryPolicy.update(new java.math.BigDecimal("10.00"), null, null, null, null, null, true);
+        when(budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, 10L)).thenReturn(Optional.of(primaryPolicy));
+        when(budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, 11L)).thenReturn(Optional.of(secondaryPolicy));
+
+        when(budgetReservationEstimator.estimate(eq("gpt-4.1-mini"), any(), any(), any()))
+            .thenReturn(BudgetReservationEstimate.reservable(
+                "gpt-4.1-mini",
+                100,
+                512,
+                new java.math.BigDecimal("0.50")
+            ));
+        when(budgetReservationEstimator.estimate(eq("claude-3-5-haiku"), any(), any(), any()))
+            .thenReturn(BudgetReservationEstimate.reservable(
+                "claude-3-5-haiku",
+                100,
+                512,
+                new java.math.BigDecimal("0.40")
+            ));
+
+        com.llm_ops.demo.budget.domain.BudgetReservation primaryReservation =
+            org.mockito.Mockito.mock(com.llm_ops.demo.budget.domain.BudgetReservation.class);
+        when(primaryReservation.getId()).thenReturn(101L);
+        com.llm_ops.demo.budget.domain.BudgetReservation secondaryReservation =
+            org.mockito.Mockito.mock(com.llm_ops.demo.budget.domain.BudgetReservation.class);
+        when(secondaryReservation.getId()).thenReturn(202L);
+        when(budgetReservationService.reserve(
+            eq(requestId),
+            anyString(),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(YearMonth.of(2026, 2)),
+            eq(new java.math.BigDecimal("10.00")),
+            eq(new java.math.BigDecimal("0.50")),
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(100),
+            eq(512),
+            any()
+        )).thenReturn(Optional.of(primaryReservation));
+        when(budgetReservationService.reserve(
+            eq(requestId),
+            anyString(),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(11L),
+            eq(YearMonth.of(2026, 2)),
+            eq(new java.math.BigDecimal("10.00")),
+            eq(new java.math.BigDecimal("0.40")),
+            eq("anthropic"),
+            eq("claude-3-5-haiku"),
+            eq(100),
+            eq(512),
+            any()
+        )).thenReturn(Optional.of(secondaryReservation));
+
+        HttpClientErrorException tooManyRequests = HttpClientErrorException.create(
+            HttpStatusCode.valueOf(429),
+            "Too Many Requests",
+            HttpHeaders.EMPTY,
+            new byte[0],
+            StandardCharsets.UTF_8
+        );
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+            .withModel("claude-3-5-haiku")
+            .withUsage(new DefaultUsage(100L, 50L, 150L))
+            .build();
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))), metadata);
+        when(llmCallService.callProvider(any(), anyString(), any(), anyString(), any()))
+            .thenThrow(tooManyRequests)
+            .thenReturn(chatResponse);
+
+        GatewayChatRequest request = new GatewayChatRequest(workspaceId, "hello", Map.of(), false);
+
+        // when
+        gatewayChatService.chat(apiKey, request);
+
+        // then
+        verify(budgetReservationService).release(101L, "PRIMARY_ROUTE_FAILED");
+        verify(budgetReservationService).settle(
+            202L,
+            com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("claude-3-5-haiku", 100, 50),
+            150L
+        );
     }
 
     @Test

--- a/src/test/java/com/llm_ops/demo/gateway/service/GatewayChatServiceUnitTest.java
+++ b/src/test/java/com/llm_ops/demo/gateway/service/GatewayChatServiceUnitTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,9 +69,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.FutureTask;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -1069,6 +1073,112 @@ class GatewayChatServiceUnitTest {
             any(),
             any()
         );
+    }
+
+    @Test
+    @DisplayName("Provider 성공 후 workspace accounting 예외가 나도 reservation을 release하지 않는다")
+    void provider_성공_후_workspace_accounting_예외가_나도_reservation을_release하지_않는다() {
+        // given
+        String apiKey = "lum_test";
+        Long organizationId = 1L;
+        Long workspaceId = 1L;
+        UUID requestId = UUID.randomUUID();
+
+        OrganizationApiKeyAuthService.AuthResult authResult =
+            new OrganizationApiKeyAuthService.AuthResult(organizationId, 99L, "lum_test");
+        when(organizationApiKeyAuthService.resolveAuthResult(apiKey)).thenReturn(authResult);
+        when(requestLogWriter.start(any())).thenReturn(requestId);
+
+        Workspace workspace = org.mockito.Mockito.mock(Workspace.class);
+        when(workspace.getId()).thenReturn(workspaceId);
+        when(workspaceRepository.findByIdAndOrganizationIdAndStatus(workspaceId, organizationId, WorkspaceStatus.ACTIVE))
+            .thenReturn(Optional.of(workspace));
+
+        com.llm_ops.demo.prompt.domain.Prompt promptEntity = org.mockito.Mockito.mock(com.llm_ops.demo.prompt.domain.Prompt.class);
+        when(promptEntity.getId()).thenReturn(100L);
+        when(promptRepository.findByWorkspaceAndPromptKeyAndStatus(eq(workspace), eq("hello"), eq(PromptStatus.ACTIVE)))
+            .thenReturn(Optional.of(promptEntity));
+
+        PromptVersion activeVersion = org.mockito.Mockito.mock(PromptVersion.class);
+        when(activeVersion.getUserTemplate()).thenReturn("hello");
+        when(activeVersion.getSystemPrompt()).thenReturn(null);
+        when(activeVersion.getProvider()).thenReturn(ProviderType.OPENAI);
+        when(activeVersion.getModel()).thenReturn("gpt-4.1-mini");
+
+        PromptRelease release = org.mockito.Mockito.mock(PromptRelease.class);
+        when(release.getActiveVersion()).thenReturn(activeVersion);
+        when(promptReleaseRepository.findWithActiveVersionByPromptId(100L)).thenReturn(Optional.of(release));
+
+        when(providerCredentialService.resolveApiKey(eq(organizationId), eq(ProviderType.OPENAI)))
+            .thenReturn(new ProviderCredentialService.ResolvedProviderApiKey(10L, ProviderType.OPENAI, "provider-key"));
+        when(budgetUsageService.currentUtcYearMonth()).thenReturn(YearMonth.of(2026, 2));
+        when(budgetGuardrailService.evaluateWorkspaceDegrade(eq(workspaceId), anyString())).thenReturn(BudgetDecision.allow());
+        when(budgetGuardrailService.evaluateProviderCredential(eq(10L))).thenReturn(BudgetDecision.allow());
+
+        BudgetPolicy policy = BudgetPolicy.createDefault(BudgetScopeType.PROVIDER_CREDENTIAL, 10L);
+        policy.update(new java.math.BigDecimal("10.00"), null, null, null, null, null, true);
+        when(budgetPolicyService.findPolicy(BudgetScopeType.PROVIDER_CREDENTIAL, 10L)).thenReturn(Optional.of(policy));
+        when(budgetReservationEstimator.estimate(eq("gpt-4.1-mini"), any(), any(), any()))
+            .thenReturn(BudgetReservationEstimate.reservable(
+                "gpt-4.1-mini",
+                120,
+                512,
+                new java.math.BigDecimal("0.50")
+            ));
+
+        com.llm_ops.demo.budget.domain.BudgetReservation reservation = org.mockito.Mockito.mock(com.llm_ops.demo.budget.domain.BudgetReservation.class);
+        when(reservation.getId()).thenReturn(33L);
+        when(budgetReservationService.reserve(
+            eq(requestId),
+            anyString(),
+            eq(BudgetScopeType.PROVIDER_CREDENTIAL),
+            eq(10L),
+            eq(YearMonth.of(2026, 2)),
+            eq(new java.math.BigDecimal("10.00")),
+            eq(new java.math.BigDecimal("0.50")),
+            eq("openai"),
+            eq("gpt-4.1-mini"),
+            eq(120),
+            eq(512),
+            any()
+        )).thenReturn(Optional.of(reservation));
+
+        ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+            .withModel("gpt-4.1-mini")
+            .withUsage(new DefaultUsage(100L, 50L, 150L))
+            .build();
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))), metadata);
+        when(llmCallService.callProvider(any(), anyString(), any(), anyString(), any())).thenReturn(chatResponse);
+        doThrow(new RuntimeException("workspace accounting failed"))
+            .when(budgetUsageService)
+            .recordUsage(
+                eq(BudgetScopeType.WORKSPACE),
+                eq(workspaceId),
+                eq(YearMonth.of(2026, 2)),
+                eq(com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("gpt-4.1-mini", 100, 50)),
+                eq(150L)
+            );
+
+        GatewayChatRequest request = new GatewayChatRequest(workspaceId, "hello", Map.of(), false);
+
+        // when // then
+        assertThatThrownBy(() -> gatewayChatService.chat(apiKey, request))
+            .isInstanceOf(GatewayException.class);
+
+        InOrder inOrder = inOrder(budgetReservationService, budgetUsageService);
+        inOrder.verify(budgetReservationService).settle(
+            33L,
+            com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("gpt-4.1-mini", 100, 50),
+            150L
+        );
+        inOrder.verify(budgetUsageService).recordUsage(
+            eq(BudgetScopeType.WORKSPACE),
+            eq(workspaceId),
+            eq(YearMonth.of(2026, 2)),
+            eq(com.llm_ops.demo.gateway.pricing.ModelPricing.calculateCost("gpt-4.1-mini", 100, 50)),
+            eq(150L)
+        );
+        verify(budgetReservationService, never()).release(33L, "RuntimeException");
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #249

## ✨ 작업 내용
- Gateway 예산 hard-limit를 Postgres 예약-정산 구조로 전환해 provider credential scope에서 동시 요청 hard-limit가 일관되게 동작하도록 변경했습니다.
- `budget_monthly_usage.reserved_cost_usd`, `budget_reservations`, 원자적 reserve/settle/release/expire repository, 비용 상한 estimator, `GatewayChatService`의 예약 → 호출 → 정산 흐름, TTL 복구 job, 메트릭/로그, 동시성 테스트와 ADR 문서를 함께 정리했습니다.
- 후속 hardening으로 terminal transition을 DB 조건부 상태 전이로 바꿔 `settle/release/expire` 경쟁이 성공 응답을 500으로 뒤집지 않도록 보강했습니다.
- 현재 rollout 의도를 문서에 명시해 `PROVIDER_CREDENTIAL` hard-limit만 strict reservation 대상으로 두고, `WORKSPACE` soft-limit는 advisory/best-effort guardrail로 정리했습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- `docs/gateway-budget-hard-limit-postgres-reservation-plan-2026-03-19.md`

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?

## 실행한 검증 명령
- `./gradlew test --tests "com.llm_ops.demo.budget.BudgetReservationMigrationTest" --tests "com.llm_ops.demo.budget.service.BudgetReservationServiceTest" --tests "com.llm_ops.demo.budget.service.BudgetGuardrailServiceTest" --tests "com.llm_ops.demo.budget.repository.BudgetMonthlyUsageRepositoryTest" --tests "com.llm_ops.demo.budget.repository.BudgetReservationRepositoryTest"`
- `./gradlew test --tests "com.llm_ops.demo.budget.service.BudgetReservationServiceTest" --tests "com.llm_ops.demo.budget.service.BudgetReservationServiceConcurrencyTest" --tests "com.llm_ops.demo.budget.service.BudgetReservationRecoveryJobTest" --tests "com.llm_ops.demo.gateway.service.GatewayChatServiceUnitTest" --tests "com.llm_ops.demo.gateway.GatewayChatControllerTest" --tests "com.llm_ops.demo.e2e.ChatCompletionE2ETest" --tests "com.llm_ops.demo.e2e.GatewayBudgetConcurrencyE2ETest"`
- `./gradlew test --tests "com.llm_ops.demo.budget.service.BudgetReservationServiceConcurrencyTest" --tests "com.llm_ops.demo.budget.service.BudgetReservationServiceTest" --tests "com.llm_ops.demo.budget.repository.BudgetReservationRepositoryTest" --tests "com.llm_ops.demo.budget.service.BudgetReservationRecoveryJobTest"`
- `./gradlew test --tests "com.llm_ops.demo.e2e.GatewayBudgetConcurrencyE2ETest"`

## 리스크 및 롤백 포인트
- 리스크: `WORKSPACE` soft-limit는 의도적으로 advisory/best-effort로 남겨두었고, reservation 상한 계산이 보수적이면 예산이 일시적으로 더 많이 묶일 수 있습니다.
- 롤백: 이 PR을 revert하면 Gateway 예산 흐름은 기존 사후 누적 기반 동작으로 복귀합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예산 예약(Reservation) 워크플로 도입으로 요청단위 예산을 사전 확보하고 만료/정산/해제 가능

* **개선**
  * PostgreSQL 기반 원자적 예약·정산으로 strict hard-limit 보장 및 soft-limit 평가에 예약금 포함
  * 게이트웨이 호출 흐름에 예약/정산/해제 통합(페일오버 시 안전한 롤백)

* **테스트**
  * 마이그레이션·저장소·서비스·E2E를 포함한 동시성 및 회귀 테스트 대폭 추가

* **문서**
  * end-to-end 설계·롤아웃·운영·테스트 전략 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->