### PR TITLE
chore: PR 기본 CI에서 RAG heavy 테스트 분리 (#253)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build & Test
-        run: ./gradlew clean build --no-build-cache -Dspring.profiles.active=test
+      - name: Test (pull request)
+        if: github.event_name == 'pull_request'
+        run: ./gradlew clean test --no-build-cache -Dspring.profiles.active=test -DexcludeTags=rag-heavy
+
+      - name: Build & Test (push)
+        if: github.event_name == 'push'
+        run: ./gradlew clean build --no-build-cache -Dspring.profiles.active=test -DexcludeTags=rag-heavy
 
       # ✅ jar를 다음 job으로 넘겨서 "중복 빌드" 제거
       - name: Upload JAR artifact

--- a/.github/workflows/rag-tests.yml
+++ b/.github/workflows/rag-tests.yml
@@ -1,0 +1,31 @@
+name: RAG Tests
+
+on:
+  push:
+    branches: ["main", "develop"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rag-heavy-tests:
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Xmx2g -XX:MaxMetaspaceSize=512m
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run rag-heavy tests
+        run: ./gradlew clean test --no-build-cache -Dspring.profiles.active=test -DincludeTags=rag-heavy

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,22 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	def includeTagsProp = System.getProperty('includeTags')
+	def excludeTagsProp = System.getProperty('excludeTags')
+
+	useJUnitPlatform {
+		if (includeTagsProp) {
+			includeTags includeTagsProp.split(',')*.trim().findAll { !it.isEmpty() } as String[]
+		}
+		if (excludeTagsProp) {
+			excludeTags excludeTagsProp.split(',')*.trim().findAll { !it.isEmpty() } as String[]
+		}
+	}
+
+	def includeTags = includeTagsProp ? includeTagsProp.split(',')*.trim().findAll { !it.isEmpty() } : []
+	if (includeTags.contains('rag-heavy')) {
+		maxHeapSize = '2g'
+	}
 }
 
 jar {

--- a/src/test/java/com/llm_ops/demo/integration/GatewayRagIntegrationTest.java
+++ b/src/test/java/com/llm_ops/demo/integration/GatewayRagIntegrationTest.java
@@ -21,6 +21,7 @@ import com.llm_ops.demo.prompt.repository.PromptVersionRepository;
 import com.llm_ops.demo.workspace.domain.Workspace;
 import com.llm_ops.demo.workspace.repository.WorkspaceRepository;
 import com.llm_ops.demo.keys.domain.ProviderType;
+import com.llm_ops.demo.support.RagHeavyTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +58,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 })
 @DisplayName("Gateway-RAG 통합 테스트")
 @Transactional
+@RagHeavyTest
 class
 GatewayRagIntegrationTest {
 

--- a/src/test/java/com/llm_ops/demo/rag/controller/DocumentControllerTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/controller/DocumentControllerTest.java
@@ -19,6 +19,7 @@ import com.llm_ops.demo.rag.service.RagDocumentIngestService;
 import com.llm_ops.demo.rag.service.RagDocumentListService;
 import com.llm_ops.demo.rag.service.RagDocumentVectorStoreDeleteService;
 import com.llm_ops.demo.rag.storage.S3ApiClient;
+import com.llm_ops.demo.support.RagHeavyTest;
 import com.llm_ops.demo.workspace.service.WorkspaceAccessService;
 import java.io.InputStream;
 import java.time.LocalDateTime;
@@ -41,6 +42,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 @TestPropertySource(properties = "storage.s3.enabled=true")
+@RagHeavyTest
 class DocumentControllerTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/controller/RagControllerTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/controller/RagControllerTest.java
@@ -9,6 +9,7 @@ import com.llm_ops.demo.rag.dto.ChunkDetailResponse;
 import com.llm_ops.demo.rag.dto.RagSearchResponse;
 import com.llm_ops.demo.rag.facade.RagSearchFacade;
 import com.llm_ops.demo.rag.service.RagDocumentVectorStoreSaveService;
+import com.llm_ops.demo.support.RagHeavyTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 @TestPropertySource(properties = "rag.vectorstore.pgvector.enabled=true")
+@RagHeavyTest
 class RagControllerTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/service/RagDocumentCreateServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/service/RagDocumentCreateServiceTest.java
@@ -4,6 +4,7 @@ import com.llm_ops.demo.global.error.BusinessException;
 import com.llm_ops.demo.global.error.ErrorCode;
 import com.llm_ops.demo.rag.domain.RagDocument;
 import com.llm_ops.demo.rag.repository.RagDocumentRepository;
+import com.llm_ops.demo.support.RagHeavyTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.ai.vectorstore.pgvector.enabled=false")
 @ImportAutoConfiguration(exclude = PgVectorStoreAutoConfiguration.class)
+@RagHeavyTest
 class RagDocumentCreateServiceTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/service/RagDocumentDeleteServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/service/RagDocumentDeleteServiceTest.java
@@ -5,6 +5,7 @@ import com.llm_ops.demo.global.error.ErrorCode;
 import com.llm_ops.demo.rag.domain.RagDocument;
 import com.llm_ops.demo.rag.domain.RagDocumentStatus;
 import com.llm_ops.demo.rag.repository.RagDocumentRepository;
+import com.llm_ops.demo.support.RagHeavyTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.ai.vectorstore.pgvector.enabled=false")
 @ImportAutoConfiguration(exclude = PgVectorStoreAutoConfiguration.class)
+@RagHeavyTest
 class RagDocumentDeleteServiceTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/service/RagDocumentIngestServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/service/RagDocumentIngestServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.llm_ops.demo.config.TestVectorStoreConfig;
+import com.llm_ops.demo.support.RagHeavyTest;
+import com.llm_ops.demo.workspace.service.WorkspaceRagSettingsService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,13 +23,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import com.llm_ops.demo.workspace.service.WorkspaceRagSettingsService;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(properties = "rag.vectorstore.pgvector.enabled=true")
 @ImportAutoConfiguration(exclude = PgVectorStoreAutoConfiguration.class)
 @Import(TestVectorStoreConfig.class)
+@RagHeavyTest
 class RagDocumentIngestServiceTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/service/RagDocumentListServiceTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/service/RagDocumentListServiceTest.java
@@ -3,6 +3,7 @@ package com.llm_ops.demo.rag.service;
 import com.llm_ops.demo.rag.domain.RagDocument;
 import com.llm_ops.demo.rag.domain.RagDocumentStatus;
 import com.llm_ops.demo.rag.repository.RagDocumentRepository;
+import com.llm_ops.demo.support.RagHeavyTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.ai.vectorstore.pgvector.enabled=false")
 @ImportAutoConfiguration(exclude = PgVectorStoreAutoConfiguration.class)
+@RagHeavyTest
 class RagDocumentListServiceTest {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/rag/service/RagSearchIntegrationTest.java
+++ b/src/test/java/com/llm_ops/demo/rag/service/RagSearchIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.llm_ops.demo.rag.service;
 
 import com.llm_ops.demo.rag.dto.RagSearchResponse;
+import com.llm_ops.demo.support.RagHeavyTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "RAG_SEARCH_IT", matches = "true")
+@RagHeavyTest
 class RagSearchIntegrationTest {
 
     private static final Long WORKSPACE_ID = 1L;

--- a/src/test/java/com/llm_ops/demo/rag/storage/S3ApiClientIT.java
+++ b/src/test/java/com/llm_ops/demo/rag/storage/S3ApiClientIT.java
@@ -1,6 +1,7 @@
 package com.llm_ops.demo.rag.storage;
 
 import com.llm_ops.demo.rag.config.StorageS3Properties;
+import com.llm_ops.demo.support.RagHeavyTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ActiveProfiles("local")
 @EnabledIfEnvironmentVariable(named = "RUN_MINIO_TESTS", matches = "true")
+@RagHeavyTest
 class S3ApiClientIT {
 
     @Autowired

--- a/src/test/java/com/llm_ops/demo/support/RagHeavyTest.java
+++ b/src/test/java/com/llm_ops/demo/support/RagHeavyTest.java
@@ -1,0 +1,16 @@
+package com.llm_ops.demo.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * PR 기본 게이트에서 제외하고 별도 워크플로우로 분리할 무거운 RAG 통합 테스트 태그입니다.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("rag-heavy")
+public @interface RagHeavyTest {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #253

## ✨ 작업 내용
- `rag-heavy` JUnit 태그를 도입해 무거운 RAG `@SpringBootTest` 계열 테스트를 분리했습니다.
- PR 기본 CI는 `test -DexcludeTags=rag-heavy`만 실행하도록 바꾸고, push 경로만 기존 `build`를 유지했습니다.
- 별도 `RAG Tests` 워크플로우를 추가해 `rag-heavy` 스위트를 독립적으로 실행하도록 구성했습니다.

## 📸 스크린샷 (선택)
- 없음

## 📚 레퍼런스 (선택)
- 없음

## ✅ 체크리스트
- [x] 빌드 및 테스트가 성공했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 출력(print)은 제거했나요?
- [x] 리뷰어가 확인해야 할 특이사항이 있나요?

## 실행한 검증 명령
- `./gradlew clean test --no-build-cache -Dspring.profiles.active=test -DexcludeTags=rag-heavy`
- `./gradlew clean test --no-build-cache -Dspring.profiles.active=test -DincludeTags=rag-heavy`

## 리스크 및 롤백 포인트
- 리스크: `rag-heavy` 분류가 더 필요한 테스트가 남아 있으면 PR CI에서 다시 무거운 컨텍스트가 실행될 수 있습니다.
- 롤백: `.github/workflows/deploy.yml`, `.github/workflows/rag-tests.yml`, `build.gradle`, `src/test/java/com/llm_ops/demo/support/RagHeavyTest.java` 중심으로 되돌리면 기존 단일 CI 구조로 복귀할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **테스트**
  * CI/CD 워크플로우가 개선되어 풀 리퀘스트에서는 테스트만 실행되고 푸시에서는 전체 빌드를 수행합니다.
  * RAG 통합 테스트가 별도의 전용 파이프라인으로 분리되어 보다 효율적으로 관리됩니다.
  * 테스트가 태그 기반으로 분류되어 선택적 실행이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->